### PR TITLE
Dev

### DIFF
--- a/src/components/SearchStatePersistence.vue
+++ b/src/components/SearchStatePersistence.vue
@@ -1,0 +1,31 @@
+<template>
+  <!-- This component watches search state and persists it -->
+  <!-- Using ais-state-results to access the current search state -->
+  <ais-state-results>
+    <template #default="{ state: searchState }">
+      <!-- Component doesn't render anything visible, just watches state -->
+      <div style="display: none;">
+        <SearchStateWatcher
+          :state="searchState"
+          :index-name="indexName"
+          @state-changed="$emit('state-changed', $event)"
+        />
+      </div>
+    </template>
+  </ais-state-results>
+</template>
+
+<script setup>
+import { useSettingsStore } from "src/stores/settings-store";
+import SearchStateWatcher from "./SearchStateWatcher.vue";
+
+defineProps({
+  indexName: {
+    type: String,
+    required: true,
+  },
+});
+
+defineEmits(["state-changed"]);
+</script>
+

--- a/src/components/SearchStateWatcher.vue
+++ b/src/components/SearchStateWatcher.vue
@@ -1,0 +1,60 @@
+<template>
+  <!-- Invisible component that watches state and saves it -->
+</template>
+
+<script setup>
+import { watch } from "vue";
+import { useSettingsStore } from "src/stores/settings-store";
+
+const props = defineProps({
+  state: {
+    type: Object,
+    required: true,
+  },
+  indexName: {
+    type: String,
+    required: true,
+  },
+});
+
+const emit = defineEmits(["state-changed"]);
+
+const theSettings = useSettingsStore();
+
+// Watch for state changes and save them
+watch(
+  () => props.state,
+  (newState) => {
+    if (!newState || !props.indexName) return;
+
+    // Extract relevant state
+    const searchState = {
+      query: newState.query || "",
+      filters: extractFilters(newState),
+      sort: newState.sortBy || "",
+      page: newState.page || 1,
+    };
+
+    // Save to store
+    theSettings.setIndexSearchState(props.indexName, searchState);
+
+    // Emit event for parent component
+    emit("state-changed", searchState);
+  },
+  { deep: true, immediate: true }
+);
+
+// Helper to extract filters from state
+function extractFilters(state) {
+  const filters = {};
+  if (state.refinementList) {
+    Object.keys(state.refinementList).forEach((key) => {
+      if (state.refinementList[key] && state.refinementList[key].length > 0) {
+        filters[key] = state.refinementList[key];
+      }
+    });
+  }
+  return filters;
+}
+</script>
+

--- a/src/pages/DocumentDetailPage.vue
+++ b/src/pages/DocumentDetailPage.vue
@@ -62,7 +62,7 @@ onMounted(async () => {
   try {
     currentIndex.value = route.params.indexUid;
     const mclient = theSettings.getIndexClient(currentIndex.value);
-    iPk.value = await mclient.fetchPrimaryKey();
+    iPk.value = (await mclient.fetchPrimaryKey()) || "id";
 
     // Check if creating a new document BEFORE trying to fetch
     if (route.params.documentUid == "new") {

--- a/src/stores/settings-store.js
+++ b/src/stores/settings-store.js
@@ -11,6 +11,8 @@ export const useSettingsStore = defineStore("settings", {
     instances: [],
     // Per-index display preferences
     indexDisplaySettings: {}, // { indexName: { imageField: 'image_url', viewMode: 'compact' } }
+    // Per-index search state persistence
+    indexSearchState: {}, // { indexName: { query: '', filters: {}, sort: '', page: 1, filtersVisible: true } }
     darkMode: true,
     // Unsaved settings tracking
     hasUnsavedSettings: false,
@@ -148,6 +150,27 @@ export const useSettingsStore = defineStore("settings", {
       };
     },
 
+    // Get search state for an index
+    getIndexSearchState(indexName) {
+      return (
+        this.indexSearchState[indexName] || {
+          query: "",
+          filters: {},
+          sort: "",
+          page: 1,
+          filtersVisible: true,
+        }
+      );
+    },
+
+    // Set search state for an index
+    setIndexSearchState(indexName, state) {
+      this.indexSearchState[indexName] = {
+        ...this.getIndexSearchState(indexName),
+        ...state,
+      };
+    },
+
     // Track unsaved settings changes
     markSettingsUnsaved() {
       this.hasUnsavedSettings = true;
@@ -165,6 +188,7 @@ export const useSettingsStore = defineStore("settings", {
       "currentInstance",
       "instances",
       "indexDisplaySettings",
+      "indexSearchState",
       "darkMode",
       // Don't persist hasUnsavedSettings - should reset on page load
     ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds per-index search state persistence (query, sort, page, filters visibility) and integrates it into the index detail page, with safer primary key handling.
> 
> - **Search State Persistence**
>   - Add `components/SearchStatePersistence.vue` and `components/SearchStateWatcher.vue` to observe InstantSearch state and save it per-index via store; emit `state-changed` events.
> - **Index Detail Page (`pages/IndexDetailPage.vue`)**
>   - Integrate persistence: hydrate `ais-configure` with `savedSearchState` (`query`, `sort-by`, `page`) and listen via `SearchStatePersistence`.
>   - Save/restore `filtersVisible` and search state per index; handle route changes to persist/restore state when switching indices.
>   - Add `getDocumentId` helper and use it for item keys, labels, and edit links.
>   - Fallback primary key to `"id"` if not set.
> - **Document Detail Page (`pages/DocumentDetailPage.vue`)**
>   - Fallback primary key to `"id"` when fetching the primary key.
> - **Store (`stores/settings-store.js`)**
>   - Add `indexSearchState` with getters/setters and include in persisted paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af326f99e93aeea479275a68343c0edc7e21e91e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->