### PR TITLE
Fix primary key retrieval to use getRawIndexes instead of fetchPrimar…

### DIFF
--- a/src/pages/DocumentDetailPage.vue
+++ b/src/pages/DocumentDetailPage.vue
@@ -44,12 +44,14 @@
 
 <script setup>
 import { useSettingsStore } from "src/stores/settings-store";
+import { useIndexesStore } from "src/stores/indexes-store";
 import { storeToRefs } from "pinia";
 import { onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import VueJsoneditor from "vue3-ts-jsoneditor";
 import { showSuccess, showError } from "src/utils/notifications";
 const theSettings = useSettingsStore();
+const indexesStore = useIndexesStore();
 const { currentIndex } = storeToRefs(theSettings);
 const route = useRoute();
 const router = useRouter();
@@ -61,8 +63,8 @@ const iPk = ref("");
 onMounted(async () => {
   try {
     currentIndex.value = route.params.indexUid;
-    const mclient = theSettings.getIndexClient(currentIndex.value);
-    iPk.value = (await mclient.fetchPrimaryKey()) || "id";
+    // Get primary key from indexes store (which has the correct primaryKey from getRawIndexes)
+    iPk.value = await indexesStore.getPrimaryKey(currentIndex.value);
 
     // Check if creating a new document BEFORE trying to fetch
     if (route.params.documentUid == "new") {

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -306,6 +306,7 @@
 <script setup>
 import { instantMeiliSearch } from "@meilisearch/instant-meilisearch";
 import { useSettingsStore } from "src/stores/settings-store";
+import { useIndexesStore } from "src/stores/indexes-store";
 import { storeToRefs } from "pinia";
 import { onMounted, ref, watch, nextTick, computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -326,6 +327,7 @@ const route = useRoute();
 const router = useRouter();
 
 const theSettings = useSettingsStore();
+const indexesStore = useIndexesStore();
 const { indexUrl, indexKey, currentIndex } = storeToRefs(theSettings);
 const iStats = ref({});
 const iSettings = ref({});
@@ -399,7 +401,8 @@ const loadInstance = async () => {
   fdRows.value = Object.keys(iStats.value.fieldDistribution).map((key) => {
     return { "Field Name": key, Count: iStats.value.fieldDistribution[key] };
   });
-  iPk.value = (await mclient.fetchPrimaryKey()) || "id";
+  // Get primary key from indexes store (which has the correct primaryKey from getRawIndexes)
+  iPk.value = await indexesStore.getPrimaryKey(currentIndex.value);
 
   // Load display settings for this index
   displaySettings.value = theSettings.getIndexDisplaySettings(

--- a/src/stores/indexes-store.js
+++ b/src/stores/indexes-store.js
@@ -108,6 +108,29 @@ export const useIndexesStore = defineStore("indexes", {
         throw error;
       }
     },
+
+    // Get primary key for an index (with fallback to fetching if not in cache)
+    async getPrimaryKey(indexUid) {
+      // First try to get from cached indexes
+      const cachedIndex = this.indexes.find((idx) => idx.uid === indexUid);
+      if (cachedIndex?.primaryKey) {
+        return cachedIndex.primaryKey;
+      }
+
+      // If not in cache, try to fetch indexes first
+      try {
+        await this.fetchIndexes();
+        const index = this.indexes.find((idx) => idx.uid === indexUid);
+        if (index?.primaryKey) {
+          return index.primaryKey;
+        }
+      } catch (error) {
+        console.error("Failed to fetch indexes for primary key:", error);
+      }
+
+      // Fallback to 'id' if not found
+      return "id";
+    },
   },
 });
 


### PR DESCRIPTION
…yKey

- Replace mclient.fetchPrimaryKey() with indexesStore.getPrimaryKey()
- fetchPrimaryKey() was incorrectly returning the distinct attribute instead of the actual primary key
- getPrimaryKey() now correctly retrieves primaryKey from getRawIndexes() response
- Added getPrimaryKey method to indexes-store with caching and fallback logic
- Updated IndexDetailPage and DocumentDetailPage to use the new method
- Fixes issue where document IDs showed as undefined when primary key wasn't 'id'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch primary key retrieval to a centralized indexes-store method and update pages to use it.
> 
> - **Primary Key Retrieval**
>   - Replace `mclient.fetchPrimaryKey()` with `indexesStore.getPrimaryKey()` in `src/pages/IndexDetailPage.vue` and `src/pages/DocumentDetailPage.vue`.
>   - Import and use `useIndexesStore` in both pages.
> - **Indexes Store (`src/stores/indexes-store.js`)**
>   - Add `getPrimaryKey(indexUid)` that returns `primaryKey` from cached `indexes` or refreshes via `fetchIndexes()` (fallback to `"id"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 107f0430e5590229ed33d2dfc3cec12b25022595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->