### PR TITLE
Fix pagination and sort by on index detail pages

### DIFF
--- a/src/components/SearchStateWatcher.vue
+++ b/src/components/SearchStateWatcher.vue
@@ -30,11 +30,12 @@ watch(
     if (!newState || !props.indexName) return;
 
     // Extract relevant state
+    // Note: InstantSearch uses 0-based page indexing internally (0 = first page, 1 = second page)
     const searchState = {
       query: newState.query || "",
       filters: extractFilters(newState),
       sort: newState.sortBy || "",
-      page: newState.page || 1,
+      page: newState.page !== undefined ? newState.page : 0,
     };
 
     // Check if this is a meaningful state change (not just initial empty state)
@@ -42,7 +43,7 @@ watch(
       searchState.query ||
       Object.keys(searchState.filters).length > 0 ||
       searchState.sort ||
-      searchState.page > 1;
+      searchState.page > 0;
 
     // On initial mount, wait until we see a non-empty state or until initialized
     // This prevents overwriting saved state with empty initial state
@@ -83,7 +84,7 @@ onMounted(() => {
         (currentState.refinementList &&
           Object.keys(currentState.refinementList).length > 0) ||
         currentState.sortBy ||
-        (currentState.page && currentState.page > 1);
+        (currentState.page !== undefined && currentState.page > 0);
       if (hasState) {
         hasSeenNonEmptyState.value = true;
       }

--- a/src/components/aisComponents/AisSortBySelect.vue
+++ b/src/components/aisComponents/AisSortBySelect.vue
@@ -2,7 +2,7 @@
   <ais-sort-by v-if="items.length" :items="items">
     <template #default="{ items: sortItems, currentRefinement, refine }">
       <q-select
-        :model-value="currentRefinement"
+        :model-value="normalizeSortValue(currentRefinement, sortItems)"
         :options="sortItems"
         option-value="value"
         option-label="label"
@@ -10,14 +10,22 @@
         outlined
         :class="selectClass"
         :label="label"
-        @update:model-value="(val) => refine(val.value)"
+        placeholder="Relevance"
+        emit-value
+        map-options
+        @update:model-value="(val) => {
+          // val is the value string, pass it directly to refine
+          refine(val);
+        }"
       />
     </template>
   </ais-sort-by>
 </template>
 
 <script setup>
-defineProps({
+import { computed } from "vue";
+
+const props = defineProps({
   items: {
     type: Array,
     required: true,
@@ -31,4 +39,23 @@ defineProps({
     default: "w-48",
   },
 });
+
+// Normalize the sort value - when currentRefinement is just the index name (default, no sort),
+// return null/undefined so q-select shows placeholder instead of the index name
+function normalizeSortValue(currentRefinement, sortItems) {
+  if (!currentRefinement) {
+    // If no refinement, return undefined to show placeholder
+    return undefined;
+  }
+  
+  // Check if currentRefinement matches any item value
+  const matchedItem = sortItems.find(item => item.value === currentRefinement);
+  if (matchedItem) {
+    return currentRefinement;
+  }
+  
+  // If currentRefinement doesn't match any item, it's likely just the index name (default)
+  // Return undefined to show placeholder instead of confusing index name
+  return undefined;
+}
 </script>

--- a/src/stores/settings-store.js
+++ b/src/stores/settings-store.js
@@ -151,13 +151,14 @@ export const useSettingsStore = defineStore("settings", {
     },
 
     // Get search state for an index
+    // Note: page is 0-based to match InstantSearch's internal format (0 = first page)
     getIndexSearchState(indexName) {
       return (
         this.indexSearchState[indexName] || {
           query: "",
           filters: {},
           sort: "",
-          page: 1,
+          page: 0,
           filtersVisible: true,
         }
       );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns pagination with InstantSearch (0-based) and refines sort behavior on index detail pages.
> 
> - Switches to 0-based `page` throughout (`SearchStateWatcher`, `settings-store`, `IndexDetailPage`), updates "has state" checks, and binds `ais-configure` with validated 0-based `page`
> - Resets `page` to 0 when the query changes and avoids restoring pagination for empty searches; tracks `previousQuery`
> - Improves `AisSortBySelect`: normalizes `currentRefinement`, shows "Relevance" placeholder when using default index, and emits value directly; options built from sortable attributes only
> - UI: moves `AisPaginationNav` to the top of results
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbe0f55d823b9fde2f835c0c1279816cf2d06fdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->