### PR TITLE
Remove Vercel-specific deployment references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Quasar application for managing multiple Meilisearch instances across development, staging, and production environments.
 
 **Version**: 2.0.0
-**Demo**: [https://meili-manager.vercel.app](https://meili-manager.vercel.app)
+**Demo**: [https://meili-manager.weeumson.com/#/](https://meili-manager.weeumson.com/#/)
 
 ## Docs
 
@@ -136,14 +136,12 @@ This allows pages to control both the main view and sidebar independently.
 
 ## Deployment
 
-### Vercel (Recommended)
+### Static Hosting
 
 - Build Command: `quasar build`
 - Output Directory: `dist/spa`
 
-### Other Platforms
-
-The application builds as a static SPA and can be hosted on any static file server.
+The application builds as a static SPA and can be hosted on any static file server (Nginx, Caddy, GitHub Pages, etc.).
 
 ### Native Applications
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "quasar build",
     "build-changelog": "node ./generateChangelog.cjs",
-    "deploy": "vercel",
+    "deploy": "echo \"Build dist/spa and deploy to your static host\"",
     "lint": "eslint --ext .js,.vue ./",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
     "test": "echo \"No test specified\" && exit 0"


### PR DESCRIPTION
Update demo URL and deployment notes to point to the static hosted showcase target.

Vercel is being deprecated/spun down.