### PR TITLE
Restore per-index facet filters when returning to document list

### DIFF
--- a/src/components/SearchStateWatcher.vue
+++ b/src/components/SearchStateWatcher.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup>
-import { watch, ref, onMounted } from "vue";
+import { watch, ref, onMounted, onBeforeUnmount } from "vue";
 import { useSettingsStore } from "src/meili-core/stores/settings-store";
 
 const props = defineProps({
@@ -23,54 +23,46 @@ const theSettings = useSettingsStore();
 const isInitialized = ref(false);
 const hasSeenNonEmptyState = ref(false);
 
+const persistFromInstantSearchState = (newState) => {
+  if (!newState || !props.indexName) return;
+
+  const searchState = {
+    query: newState.query || "",
+    filters: extractFilters(newState),
+    sort: newState.sortBy || "",
+    page: newState.page !== undefined ? newState.page : 0,
+  };
+
+  const hasState =
+    searchState.query ||
+    Object.keys(searchState.filters).length > 0 ||
+    searchState.sort ||
+    searchState.page > 0;
+
+  if (!isInitialized.value) {
+    if (hasState) {
+      hasSeenNonEmptyState.value = true;
+      isInitialized.value = true;
+    } else {
+      return;
+    }
+  }
+
+  if (hasSeenNonEmptyState.value || hasState) {
+    const existingState = theSettings.getIndexSearchState(props.indexName);
+    theSettings.setIndexSearchState(props.indexName, {
+      ...existingState,
+      ...searchState,
+    });
+    emit("state-changed", searchState);
+  }
+};
+
 // Watch for state changes and save them
 watch(
   () => props.state,
   (newState) => {
-    if (!newState || !props.indexName) return;
-
-    // Extract relevant state
-    // Note: InstantSearch uses 0-based page indexing internally (0 = first page, 1 = second page)
-    const searchState = {
-      query: newState.query || "",
-      filters: extractFilters(newState),
-      sort: newState.sortBy || "",
-      page: newState.page !== undefined ? newState.page : 0,
-    };
-
-    // Check if this is a meaningful state change (not just initial empty state)
-    const hasState =
-      searchState.query ||
-      Object.keys(searchState.filters).length > 0 ||
-      searchState.sort ||
-      searchState.page > 0;
-
-    // On initial mount, wait until we see a non-empty state or until initialized
-    // This prevents overwriting saved state with empty initial state
-    if (!isInitialized.value) {
-      if (hasState) {
-        hasSeenNonEmptyState.value = true;
-        isInitialized.value = true;
-      } else {
-        // Wait a bit for ais-configure to apply saved state
-        // If state is still empty after initialization delay, it's likely truly empty
-        return;
-      }
-    }
-
-    // Only save if we've seen a non-empty state or if this is a meaningful change
-    // This prevents overwriting saved state with empty state on initial mount
-    if (hasSeenNonEmptyState.value || hasState) {
-      // Save to store
-      const existingState = theSettings.getIndexSearchState(props.indexName);
-      theSettings.setIndexSearchState(props.indexName, {
-        ...existingState,
-        ...searchState,
-      });
-
-      // Emit event for parent component
-      emit("state-changed", searchState);
-    }
+    persistFromInstantSearchState(newState);
   },
   { deep: true },
 );
@@ -94,6 +86,10 @@ onMounted(() => {
       }
     }
   }, 100);
+});
+
+onBeforeUnmount(() => {
+  persistFromInstantSearchState(props.state);
 });
 
 // Helper to extract filters from state

--- a/src/meili-core/utils/search-utils.js
+++ b/src/meili-core/utils/search-utils.js
@@ -40,3 +40,23 @@ export const buildHybridConfig = (state) => {
   }
   return hybrid;
 };
+
+export const buildRefinementListFromFilters = (filters = {}) => {
+  const refinementList = {};
+  for (const [attribute, values] of Object.entries(filters)) {
+    if (Array.isArray(values) && values.length > 0) {
+      refinementList[attribute] = [...values];
+    }
+  }
+  return refinementList;
+};
+
+export const hasActiveSavedSearch = (state = {}) => {
+  const filters = state.filters || {};
+  const hasFilters = Object.values(filters).some(
+    (values) => Array.isArray(values) && values.length > 0,
+  );
+  return Boolean(
+    state.query?.trim() || hasFilters || state.sort || (state.page ?? 0) > 0,
+  );
+};

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -238,13 +238,14 @@ import { useIndexesStore } from "src/meili-core/stores/indexes-store";
 import {
   normalizeThreshold,
   getDefaultIndexSearchState,
+  buildRefinementListFromFilters,
 } from "src/meili-core/utils/search-utils";
 import {
   getCompatFeatures,
   buildCompatibleSearchParams,
 } from "src/meili-core/utils/meili-compat";
 import { storeToRefs } from "pinia";
-import { onMounted, ref, watch, nextTick, computed } from "vue";
+import { onMounted, ref, watch, nextTick, computed, onBeforeUnmount } from "vue";
 import { useRoute } from "vue-router";
 import IndexDetailTabs from "components/IndexDetailTabs.vue";
 import SettingsForm from "components/SettingsForm.vue";
@@ -364,6 +365,9 @@ const searchParams = computed(() => {
     savedSearchState.value,
     meiliCompat.value,
   );
+  const refinementList = buildRefinementListFromFilters(
+    savedSearchState.value.filters,
+  );
   const params = {
     hitsPerPage: 50,
     query: savedSearchState.value.query || undefined,
@@ -374,6 +378,9 @@ const searchParams = computed(() => {
         : undefined,
     ...compatParams,
   };
+  if (Object.keys(refinementList).length > 0) {
+    params.refinementList = refinementList;
+  }
   if (filterableAttributes.value.length > 0) {
     params.facets = filterableAttributes.value;
   }
@@ -657,13 +664,7 @@ const loadInstance = async () => {
   filtersVisible.value = savedState.filtersVisible ?? true;
   filtersPanelWidth.value = savedState.filtersPanelWidth ?? 380;
   detailPanelTab.value = savedState.detailPanelTab ?? "documents";
-  // Initialize previous query to detect query changes
   previousQuery.value = savedState.query || "";
-  // If there's no saved query, reset page to 0 (first page, 0-based)
-  // Don't restore pagination for empty searches
-  if (!savedState.query) {
-    savedSearchState.value.page = 0;
-  }
 
   // Build image field options from all fields
   imageFieldOptions.value = fdRows.value.map((row) => row["Field Name"]);
@@ -800,6 +801,12 @@ onMounted(async () => {
 
   // Set up watchers for search state after component is mounted
   await nextTick();
+});
+
+onBeforeUnmount(() => {
+  if (currentIndex.value) {
+    persistSearchState();
+  }
 });
 
 watch(


### PR DESCRIPTION
- Pass saved filters to ais-configure as refinementList on index detail load
- Keep pagination when browsing with filters but no query text
- Flush search state to the store on unmount before doc edit navigation