### PR TITLE
Fix list field rendering and table pagination totals

### DIFF
--- a/src/components/documents/DocumentHitCard.vue
+++ b/src/components/documents/DocumentHitCard.vue
@@ -6,9 +6,9 @@
   >
     <q-card-section class="p-3">
       <div class="flex gap-3">
-        <div v-if="imageField && item[imageField]" class="flex-shrink-0">
+        <div v-if="imageField && getDocumentFieldValue(item, imageField)" class="flex-shrink-0">
           <q-img
-            :src="item[imageField]"
+            :src="getDocumentFieldValue(item, imageField)"
             :alt="documentId"
             class="rounded"
             style="width: 64px; height: 64px; object-fit: cover"
@@ -62,9 +62,10 @@
               <span class="text-gray-600 dark:text-gray-400">{{ field }}:</span>
               <span
                 class="ml-1 dark:text-gray-200 break-all"
-                :title="formatFieldValue(item[field])"
+                :class="{ 'text-gray-400 italic': fieldDisplay(field).missing }"
+                :title="fieldDisplay(field).title"
               >
-                {{ formatFieldValue(item[field]) }}
+                {{ fieldDisplay(field).text }}
               </span>
             </div>
           </div>
@@ -79,8 +80,9 @@ import { computed, ref, watch } from "vue";
 import {
   resolveListFieldsForItem,
   resolveCompactPreviewFields,
-  formatDocumentFieldValue,
+  formatDocumentFieldDisplay,
   getDocumentTitleLabel,
+  getDocumentFieldValue,
 } from "src/meili-core/utils/display-settings";
 
 const props = defineProps({
@@ -132,6 +134,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  includeConfiguredMissing: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const expanded = ref(false);
@@ -146,6 +152,7 @@ watch(
 const allFieldsForItem = computed(() =>
   resolveListFieldsForItem(props.resolvedListFields, props.item, {
     useAllItemFields: props.useAllItemFields,
+    includeConfiguredMissing: props.includeConfiguredMissing,
     primaryKey: props.primaryKey,
     imageField: props.imageField,
   }),
@@ -182,5 +189,8 @@ const gridClass = computed(() => {
   return "grid-cols-1 md:grid-cols-2";
 });
 
-const formatFieldValue = (value) => formatDocumentFieldValue(value);
+const fieldDisplay = (field) =>
+  formatDocumentFieldDisplay(props.item, field, {
+    showMissing: props.includeConfiguredMissing,
+  });
 </script>

--- a/src/components/documents/DocumentsDisplayMenu.vue
+++ b/src/components/documents/DocumentsDisplayMenu.vue
@@ -102,6 +102,10 @@
       <q-item v-if="listFieldsSourceLabel">
         <q-item-section>
           <q-item-label caption>{{ listFieldsSourceLabel }}</q-item-label>
+          <q-item-label v-if="displaySettings.listFields?.length" caption class="mt-1">
+            Fields show — when absent from search hits; add them to index
+            displayedAttributes to load values.
+          </q-item-label>
         </q-item-section>
       </q-item>
     </q-list>

--- a/src/components/documents/DocumentsHitsColumn.vue
+++ b/src/components/documents/DocumentsHitsColumn.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="min-w-0 pl-3 flex flex-col flex-1 min-h-0">
+    <ais-stats>
+      <template #default="{ nbHits, page, hitsPerPage }">
+        <span v-show="false">{{ syncSearchStats(nbHits, page, hitsPerPage) }}</span>
+      </template>
+    </ais-stats>
+
     <div class="flex justify-center mb-3 flex-shrink-0">
       <AisPaginationNav :padding="2" />
     </div>
@@ -24,6 +30,11 @@
           :image-field="displaySettings.imageField"
           :resolved-list-fields="resolvedListFields"
           :use-all-item-fields="useAllItemFields"
+          :use-configured-field-list="includeConfiguredMissing"
+          :include-configured-missing="includeConfiguredMissing"
+          :nb-hits="searchStats.nbHits"
+          :current-page="searchStats.page"
+          :hits-per-page="searchStats.hitsPerPage"
         />
         <div v-else class="flex flex-col gap-2 overflow-y-auto flex-1 min-h-0">
           <DocumentHitCard
@@ -35,6 +46,7 @@
             :image-field="displaySettings.imageField"
             :resolved-list-fields="resolvedListFields"
             :use-all-item-fields="useAllItemFields"
+            :include-configured-missing="includeConfiguredMissing"
             :list-view-mode="displaySettings.listViewMode"
             :compact-field-limit="displaySettings.compactFieldLimit || 4"
             :list-columns="displaySettings.listColumns"
@@ -53,6 +65,7 @@
 </template>
 
 <script setup>
+import { ref } from "vue";
 import AisPaginationNav from "components/aisComponents/AisPaginationNav.vue";
 import DocumentHitCard from "components/documents/DocumentHitCard.vue";
 import DocumentsHitsTable from "components/documents/DocumentsHitsTable.vue";
@@ -82,11 +95,30 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  includeConfiguredMissing: {
+    type: Boolean,
+    default: false,
+  },
   showSimilar: {
     type: Boolean,
     default: false,
   },
 });
+
+const searchStats = ref({
+  nbHits: 0,
+  page: 0,
+  hitsPerPage: 50,
+});
+
+const syncSearchStats = (nbHits, page, hitsPerPage) => {
+  searchStats.value = {
+    nbHits: nbHits ?? 0,
+    page: page ?? 0,
+    hitsPerPage: hitsPerPage ?? 50,
+  };
+  return "";
+};
 
 const documentId = (item, index) =>
   getDocumentIdFromItem(item, props.primaryKey) ?? `row-${index}`;

--- a/src/components/documents/DocumentsHitsTable.vue
+++ b/src/components/documents/DocumentsHitsTable.vue
@@ -1,46 +1,59 @@
 <template>
-  <q-table
-    flat
-    bordered
-    dense
-    :rows="rows"
-    :columns="columns"
-    :row-key="rowKey"
-    :rows-per-page-options="[10, 25, 50]"
-    class="documents-hits-table"
-  >
-    <template #body-cell-actions="cell">
-      <q-td :props="cell" auto-width>
-        <q-btn
-          flat
-          dense
-          round
-          size="sm"
-          icon="edit"
-          color="primary"
-          :to="cell.row.__editRoute"
-        />
-      </q-td>
-    </template>
-    <template
-      v-for="field in tableFields"
-      :key="field"
-      #[`body-cell-${field}`]="cell"
+  <div class="documents-hits-table-wrap flex flex-col min-h-0">
+    <q-table
+      flat
+      bordered
+      dense
+      :rows="rows"
+      :columns="columns"
+      :row-key="rowKey"
+      hide-pagination
+      virtual-scroll
+      :virtual-scroll-item-size="36"
+      class="documents-hits-table flex-1 min-h-0"
+      :style="{ maxHeight: tableMaxHeight }"
     >
-      <q-td :props="cell">
-        <span class="text-xs break-all" :title="cell.row[field]">
-          {{ cell.row[field] }}
-        </span>
-      </q-td>
-    </template>
-  </q-table>
+      <template #body-cell-actions="cell">
+        <q-td :props="cell" auto-width>
+          <q-btn
+            flat
+            dense
+            round
+            size="sm"
+            icon="edit"
+            color="primary"
+            :to="cell.row.__editRoute"
+          />
+        </q-td>
+      </template>
+      <template
+        v-for="field in tableFields"
+        :key="field"
+        #[`body-cell-${field}`]="cell"
+      >
+        <q-td :props="cell">
+          <span
+            class="text-xs break-all"
+            :class="{ 'text-gray-400 italic': cell.row[`__missing__${field}`] }"
+            :title="cell.row[`__title__${field}`]"
+          >
+            {{ cell.row[field] }}
+          </span>
+        </q-td>
+      </template>
+    </q-table>
+
+    <div class="text-caption text-gray-500 dark:text-gray-400 py-2 px-1 text-center flex-shrink-0">
+      {{ pageSummary }}
+    </div>
+  </div>
 </template>
 
 <script setup>
 import { computed } from "vue";
 import {
   buildDocumentRoutes,
-  formatDocumentFieldValue,
+  formatDocumentFieldDisplay,
   getDocumentIdFromItem,
   resolveTableFields,
 } from "src/meili-core/utils/display-settings";
@@ -70,11 +83,33 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  useConfiguredFieldList: {
+    type: Boolean,
+    default: false,
+  },
+  includeConfiguredMissing: {
+    type: Boolean,
+    default: false,
+  },
   tableFieldLimit: {
     type: Number,
     default: 8,
   },
+  nbHits: {
+    type: Number,
+    default: 0,
+  },
+  currentPage: {
+    type: Number,
+    default: 0,
+  },
+  hitsPerPage: {
+    type: Number,
+    default: 50,
+  },
 });
+
+const tableMaxHeight = "calc(100vh - 280px)";
 
 const tableFields = computed(() =>
   resolveTableFields({
@@ -83,6 +118,7 @@ const tableFields = computed(() =>
     primaryKey: props.primaryKey,
     imageField: props.imageField,
     useAllItemFields: props.useAllItemFields,
+    useConfiguredFieldList: props.useConfiguredFieldList,
     limit: props.tableFieldLimit,
   }),
 );
@@ -112,11 +148,27 @@ const rows = computed(() =>
       __editRoute: routes.edit,
     };
     for (const field of tableFields.value) {
-      row[field] = formatDocumentFieldValue(item[field], { truncate: 120 });
+      const display = formatDocumentFieldDisplay(item, field, {
+        truncate: 120,
+        showMissing: props.includeConfiguredMissing,
+      });
+      row[field] = display.text;
+      row[`__title__${field}`] = display.title;
+      row[`__missing__${field}`] = display.missing;
     }
     return row;
   }),
 );
 
 const rowKey = (row) => row.__rowKey;
+
+const pageSummary = computed(() => {
+  const total = props.nbHits || props.items.length;
+  const page = props.currentPage + 1;
+  const start = props.currentPage * props.hitsPerPage + 1;
+  const end = Math.min(start + props.items.length - 1, total);
+  if (total <= 0) return "No matching documents";
+  if (props.items.length === 0) return `${total.toLocaleString()} matching documents`;
+  return `Showing ${start.toLocaleString()}–${end.toLocaleString()} of ${total.toLocaleString()} matching documents (search page ${page})`;
+});
 </script>

--- a/src/meili-core/utils/display-settings.js
+++ b/src/meili-core/utils/display-settings.js
@@ -47,6 +47,29 @@ export const getDocumentIdFromItem = (item, primaryKey = "") => {
   return id;
 };
 
+export const MISSING_FIELD_LABEL = "—";
+export const MISSING_FIELD_TOOLTIP =
+  "Not returned in search hits. Add this field to the index displayedAttributes setting.";
+
+export const getDocumentFieldValue = (item, fieldPath) => {
+  if (!item || !fieldPath) return undefined;
+  if (Object.hasOwn(item, fieldPath)) return item[fieldPath];
+
+  const parts = String(fieldPath).split(".");
+  if (parts.length === 1) return undefined;
+
+  let current = item;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    if (!Object.hasOwn(current, part)) return undefined;
+    current = current[part];
+  }
+  return current;
+};
+
+export const isDocumentFieldPresent = (item, fieldPath) =>
+  getDocumentFieldValue(item, fieldPath) !== undefined;
+
 export const formatDocumentFieldValue = (value, { truncate = 0 } = {}) => {
   if (value === null || value === undefined) return "";
   if (typeof value === "object") return JSON.stringify(value);
@@ -55,6 +78,21 @@ export const formatDocumentFieldValue = (value, { truncate = 0 } = {}) => {
     return `${text.slice(0, truncate)}…`;
   }
   return text;
+};
+
+export const formatDocumentFieldDisplay = (
+  item,
+  fieldPath,
+  { truncate = 0, showMissing = false } = {},
+) => {
+  const value = getDocumentFieldValue(item, fieldPath);
+  if (value === undefined) {
+    return showMissing
+      ? { text: MISSING_FIELD_LABEL, title: MISSING_FIELD_TOOLTIP, missing: true }
+      : { text: "", title: "", missing: true };
+  }
+  const text = formatDocumentFieldValue(value, { truncate });
+  return { text, title: text, missing: false };
 };
 
 export const getDocumentTitleLabel = (item, primaryKey = "", documentId) => {
@@ -79,6 +117,7 @@ export const resolveTableFields = ({
   primaryKey = "",
   imageField = null,
   useAllItemFields = false,
+  useConfiguredFieldList = false,
   limit = 8,
 }) => {
   let fields = [...resolvedListFields];
@@ -97,7 +136,8 @@ export const resolveTableFields = ({
     primaryKey,
     ...fields.filter((field) => field && field !== primaryKey && field !== imageField),
   ].filter(Boolean);
-  return [...new Set(withPk)].slice(0, limit);
+  const unique = [...new Set(withPk)];
+  return useConfiguredFieldList ? unique : unique.slice(0, limit);
 };
 
 export const resolveFilterableAttributes = (
@@ -173,13 +213,19 @@ export const resolveListFields = ({
 export const resolveListFieldsForItem = (
   resolvedFields,
   item,
-  { useAllItemFields = false, primaryKey = "", imageField = null } = {},
+  {
+    useAllItemFields = false,
+    includeConfiguredMissing = false,
+    primaryKey = "",
+    imageField = null,
+  } = {},
 ) => {
   if (useAllItemFields && item && typeof item === "object") {
     return excludeReservedFields(Object.keys(item), primaryKey, imageField);
   }
   if (!item || typeof item !== "object") return resolvedFields;
-  return resolvedFields.filter((field) => Object.hasOwn(item, field));
+  if (includeConfiguredMissing) return resolvedFields;
+  return resolvedFields.filter((field) => isDocumentFieldPresent(item, field));
 };
 
 export const getListFieldsSourceLabel = ({

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -561,12 +561,17 @@ const useAllItemFields = computed(() =>
   }),
 );
 
+const includeConfiguredMissing = computed(
+  () => (displaySettings.value.listFields || []).length > 0,
+);
+
 const hitsColumnProps = computed(() => ({
   currentIndex: currentIndex.value,
   primaryKey: iPk.value,
   displaySettings: displaySettings.value,
   resolvedListFields: resolvedListFields.value,
   useAllItemFields: useAllItemFields.value,
+  includeConfiguredMissing: includeConfiguredMissing.value,
   showSimilar:
     meiliCompat.value.supportsSimilarEndpoint && hasConfiguredEmbedders.value,
 }));


### PR DESCRIPTION
- Show all configured list columns in table view and mark missing hit fields with —
- Resolve dot-path field values and explain displayedAttributes requirement in UI
- Remove q-table page slicing; footer reflects InstantSearch nbHits and search page