### PR TITLE
v2.1.0: Theme catalog, index-first UX, and Playground

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@
 ### Critical Files
 
 - `src/meili-core/stores/settings-store.js`: Credentials, `indexSearchState`, `indexDisplaySettings`, `indexPlaygroundState`, last visit, playground seed. Actions: `getIndexClient`, `rawRequest`, `switchInstance`, `setLastIndexVisit`, playground get/set/seed helpers.
-- `src/meili-core/utils/playground-request.js`: curl/HTTP/n8n export helpers + raw fetch Send.
+- `src/meili-core/utils/playground-request.js`: curl/HTTP/n8n (pasteable HTTP Request workflow snippet) export helpers + raw fetch Send.
 - `src/meili-core/utils/display-settings.js`: List-field resolution and document id/title helpers.
 - `src/pages/IndexDetailPage.vue`: Workspace tabs, document side panel, Playground bridge.
 - `src/components/playground/PlaygroundPanel.vue` / `documents/DocumentSidePanel.vue`: Playground and JSON inspector.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,20 +15,21 @@
 
 ### Key Data Flow
 
-1. **Instance Management**: `settings-store.js` holds `instances[]` array with `{label, indexUrl, indexKey}` objects persisted via `pinia-plugin-persistedstate`.
-2. **Centralized MeiliSearch Client**: Store provides `getMeiliClient()` action that returns validated, cached client. Components call `await theSettings.getMeiliClient()` instead of creating clients directly.
-3. **Instance Switching**: Store actions `switchInstance(index)`, `addInstance(label, url, key)`, `removeInstance(index)` handle validation and state updates.
-4. **Preview Mode**: Separate `preview-store.js` for shareable dashboard configs. Uses `jose` for tokenizing settings (future sharing feature). Preview has its own instance/index selection independent of main app.
-5. **Named Router Views**: `MainLayout.vue` uses dual `<router-view>` slots (`name="main"` and `name="side"`) for page content + sidebar. See `routes.js` for `components: { main: PageVue, side: SidebarVue }` pattern.
+1. **Instance Management**: `settings-store.js` holds `instances[]` with `{label, indexUrl, indexKey}` persisted via `pinia-plugin-persistedstate`. UI: `/instances`.
+2. **Centralized MeiliSearch Client**: Store `client` getter + `getIndexClient(name)`, `rawRequest`, and Playground `executePlaygroundRequest`. Do not construct Meilisearch clients in pages.
+3. **Instance Switching**: `switchInstance(index)`, `addInstance(label, url, key)`, `removeInstance(index)` validate and update credentials.
+4. **Index workspace**: `/index-details/:uid?tab=` with Documents | Settings | Playground | Overview. Resume via `lastIndexUid` / `lastIndexTab`.
+5. **Preview Mode**: `preview-store.js` remains; Preview routes are disabled in `routes.js`. Do not revive unless asked.
+6. **Shell**: `MainLayout.vue` persistent left drawer + context header chip. Single default `<router-view>` (no named main/side views).
 
 ### Critical Files
 
-- `src/meili-core/stores/settings-store.js`: Centralized client management. State: instances, `indexSearchState`, `indexDisplaySettings`, `indexSettingsCache`. Actions: `getMeiliClient()`, `getIndexClient(name)`, `switchInstance(index)`, `addInstance()`, `removeInstance()`, `getIndexDisplaySettings()`, `setIndexDisplaySettings()`, `getIndexSettingsCache()`, `setIndexSettingsCache()`.
-- `src/meili-core/utils/display-settings.js`: Headless list-field resolution, compact/detailed/table display defaults, document id/title formatting (used by `src/components/documents/*`).
-- `src/meili-core/stores/preview-store.js`: Preview configs with `previewSettings` object (pagination, filters, sortable/image/heading attributes). Actions: `savePreviewSettings()`, `loadPreviewSettings()`, `tokenizePreviewSettings()`.
-- `src/boot/instant-search.js`: Registers Vue InstantSearch globally (used in `IndexDetailPage.vue` and `PreviewPage.vue` for live search UI).
-- `src/pages/IndexDetailPage.vue`: Index detail with Documents / Overview / Settings tabs; Documents tab uses `DocumentsFiltersPanel`, `DocumentsHitsColumn`, `DocumentsDisplayMenu`, and `SearchExperiencePanel`.
-- `quasar.config.js`: Boot files order matters. Current: `['instant-search']`. Uses ES modules (`import`/`export`).
+- `src/meili-core/stores/settings-store.js`: Credentials, `indexSearchState`, `indexDisplaySettings`, `indexPlaygroundState`, last visit, playground seed. Actions: `getIndexClient`, `rawRequest`, `switchInstance`, `setLastIndexVisit`, playground get/set/seed helpers.
+- `src/meili-core/utils/playground-request.js`: curl/HTTP/n8n export helpers + raw fetch Send.
+- `src/meili-core/utils/display-settings.js`: List-field resolution and document id/title helpers.
+- `src/pages/IndexDetailPage.vue`: Workspace tabs, document side panel, Playground bridge.
+- `src/components/playground/PlaygroundPanel.vue` / `documents/DocumentSidePanel.vue`: Playground and JSON inspector.
+- `quasar.config.js`: Boot `['instant-search']`; brand tokens; no `roboto-font` (IBM Plex via `app.scss`).
 
 ## Developer Workflows
 
@@ -101,7 +102,7 @@ showPrompt("Enter name", "What's your name?", (value) => {
 - **Forms**: `<q-form @submit="onSubmit">` with `q-input`/`q-select` and inline `:rules` arrays
 - **Dialogs**: `q-dialog` with `v-model` + `persistent` prop for confirmations
 - **Tables**: `q-table` with `:rows`, `:columns`, `row-key`
-- **Drawers**: `q-drawer` with `behavior="mobile"` for responsive sidebars
+- **Drawers**: persistent left nav (`show-if-above`); document inspector uses right overlay drawer
 - **Icons**: Material icons only: `<q-icon name="delete">` (not FontAwesome)
 
 ### Tailwind Utilities

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,15 @@ node_modules
 node_modules/
 dist/
 
+# Local env (never commit secrets)
+.env
+.env.*
+
 # Quasar core related directories
 .quasar
+
+# Browser extension scaffold only (not product)
+src-bex/
 
 # Cordova related directories and files
 /src-cordova/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ yarn-error.log*
 *.njsproj
 *.sln
 .vercel
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+tests/e2e/screenshots/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Weeumson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ Paginated, sortable, searchable table of recent tasks (capped around the most re
 
 ---
 
+## License
+
+MIT. See [`LICENSE`](LICENSE).
+
 ## Contributing
 
 Issues and PRs are welcome. Keep changes focused; prefer extending `meili-core` carefully over breaking store contracts. Run `npm run lint` before opening a PR. Manual acceptance ideas against a real index are listed in [`docs/workspace-ux.md`](docs/workspace-ux.md) and the UX overhaul plan checklist (Continue, side panel Esc/copy, settings Submit, Playground redacted curl, drawer Instances/Keys/Tasks/Rules).

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Open an index to work in peer tabs: **Documents** | **Settings** | **Playground*
 - Indexes home: cluster stats, dense list, **Continue** for last index/tab
 - Documents: InstantSearch browser; click a hit for a JSON side panel (copy, edit toggle, Open in Playground, full editor)
 - Settings: category jump + sticky unsaved/Submit bar (explicit save only)
-- Playground: raw HTTP builder with redacted curl / HTTP / n8n JSON exports (with-key secondary copies)
+- Playground: raw HTTP builder with redacted curl / HTTP / canvas-pasteable n8n HTTP Request JSON (with-key secondary copies)
 
 See [`docs/workspace-ux.md`](docs/workspace-ux.md).
 
@@ -252,7 +252,7 @@ InstantSearch browser:
 
 ### Playground
 
-Craft `GET`/`POST`/… requests scoped to the current index, Send, inspect status/timing/JSON, copy redacted curl (default) or with-key / HTTP / n8n JSON. Seed from Documents hit or diagnostics. See [`docs/workspace-ux.md`](docs/workspace-ux.md).
+Craft `GET`/`POST`/… requests scoped to the current index, Send, inspect status/timing/JSON, copy redacted curl (default) or with-key / HTTP / n8n workflow JSON (paste onto the n8n canvas). Seed from Documents hit or diagnostics. See [`docs/workspace-ux.md`](docs/workspace-ux.md).
 
 ### Endpoints/Methods used
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source Quasar (Vue 3) app for managing multiple Meilisearch instances across development, staging, and production.
 
-**Version**: 2.0.0  
+**Version**: 2.1.0  
 **Demo**: [https://meili-manager.weeumson.com/#/](https://meili-manager.weeumson.com/#/)
 
 Credentials never leave the browser: instance URLs and API keys are stored in `localStorage` via Pinia persisted state. Do not commit secrets.

--- a/README.md
+++ b/README.md
@@ -1,103 +1,103 @@
 # Meili-Manager
 
-A Quasar application for managing multiple Meilisearch instances across development, staging, and production environments.
+Open-source Quasar (Vue 3) app for managing multiple Meilisearch instances across development, staging, and production.
 
-**Version**: 2.0.0
+**Version**: 2.0.0  
 **Demo**: [https://meili-manager.weeumson.com/#/](https://meili-manager.weeumson.com/#/)
+
+Credentials never leave the browser: instance URLs and API keys are stored in `localStorage` via Pinia persisted state. Do not commit secrets.
 
 ## Docs
 
-- Reuse/fork/embed playbook: `docs/reuse-and-embedding.md`
-- Headless core (copy-paste): `src/meili-core/README.md`
-- Release readiness summary: `docs/release-readiness-1.42.md`
-- Dual-version QA checklist: `docs/qa-checklist-1.11-1.42.md`
-- GitHub release draft: `RELEASE_DRAFT_1.42.md`
+- Workspace UX (index-first, Playground, side panel): [`docs/workspace-ux.md`](docs/workspace-ux.md)
+- Reuse/fork/embed playbook: [`docs/reuse-and-embedding.md`](docs/reuse-and-embedding.md)
+- Headless core (copy-paste): [`src/meili-core/README.md`](src/meili-core/README.md)
+- Dynamic search rules: [`docs/dynamic-search-rules.md`](docs/dynamic-search-rules.md)
+- Release readiness summary: [`docs/release-readiness-1.42.md`](docs/release-readiness-1.42.md)
+- Dual-version QA checklist: [`docs/qa-checklist-1.11-1.42.md`](docs/qa-checklist-1.11-1.42.md)
+- GitHub release draft: [`RELEASE_DRAFT_1.42.md`](RELEASE_DRAFT_1.42.md)
 
-## Quick Start
-
-## Install the dependencies
+## Quick start
 
 ```bash
 npm install
-npm install -g @quasar/cli
+npm run lint
+npx quasar dev
 ```
 
-### Development
+The Quasar CLI is available via `npx` (or `@quasar/cli` if you prefer a global install). Dev server defaults to the Quasar/Vite port (usually `http://localhost:9000/`). Hash routing is used so the SPA works on static hosts such as `meili-manager.weeumson.com`.
+
+### Production build
 
 ```bash
-quasar dev
-```
-
-### Production Build
-
-```bash
-quasar build
+npx quasar build
 ```
 
 Output: `dist/spa/`
 
 ### Changelog
 
-Generate changelog from git history:
-
 ```bash
 npm run build-changelog
 ```
 
-Generates `changelog.json` with versioned entries grouped by ISO week. The changelog is automatically generated and deployed with each release to GitHub Pages.
+Generates `changelog.json` with versioned entries grouped by ISO week.
 
-### Code Quality
+### Code quality
 
 ```bash
 npm run lint
 npm run format
 ```
 
-## Core Features
+## Core features
 
-### Broad Version Compatibility
+### Broad version compatibility
 
 The UI is tuned for backward-compatible operation across legacy and modern Meilisearch servers. Current target support is:
 
 - `1.11.x` (legacy-safe behavior with feature gating)
 - `1.42.x` (full modern CE capabilities exposed in UI)
 
-### Multi-Instance Management
+### Multi-instance management
 
-Save and switch between multiple Meilisearch instances (development, staging, production). Credentials are persisted locally with automatic connection validation.
+Save and switch instances on the **Instances** page (drawer nav). Credentials are validated on add/switch and persisted locally.
 
-### Index Operations
+### Index-first workspace
 
-- List, create, edit, and delete indexes
-- View statistics and field distribution
-- Configure all index settings through an intuitive interface
-- Interactive search with Vue InstantSearch widgets
+Open an index to work in peer tabs: **Documents** | **Settings** | **Playground** | Overview.
 
-### Document Management
+- Indexes home: cluster stats, dense list, **Continue** for last index/tab
+- Documents: InstantSearch browser; click a hit for a JSON side panel (copy, edit toggle, Open in Playground, full editor)
+- Settings: category jump + sticky unsaved/Submit bar (explicit save only)
+- Playground: raw HTTP builder with redacted curl / HTTP / n8n JSON exports (with-key secondary copies)
 
-- Browse and search documents with resizable facet filters, compact/detailed/table views, and per-index display preferences
-- Edit documents using a full-featured JSON editor
-- Add new documents with validation
+See [`docs/workspace-ux.md`](docs/workspace-ux.md).
 
-### API Key Management
+### API keys and tasks
 
 - Create and manage API keys with granular permissions
-- Update and delete existing keys
-- View all keys with detailed information
+- Monitor recent tasks (sortable/searchable table, cancel selected when supported)
 
-### Task Monitoring
+### Dynamic search rules
 
-- View the latest 1000 tasks in real-time
-- Sort and search through task history
-- View detailed error information for failed tasks
+Experimental condition-based pinning UI when the server exposes the feature. See [`docs/dynamic-search-rules.md`](docs/dynamic-search-rules.md).
 
-### Preview Mode (Experimental)
+### Preview mode (disabled)
 
-- Create custom search previews with configurable UI
-- Save multiple preview configurations
-- Independent instance/index selection per preview
+Preview routes remain in the tree but are disabled in the router. Do not revive them unless you are intentionally working that alpha surface.
 
-## Key Dependencies
+## Theme
+
+Dark Weeumson docs-style shell by default:
+
+- IBM Plex Sans
+- Primary `#b85538`, elevated page surfaces, square cards/buttons
+- Tailwind v4 theme tokens in `src/css/tailwind.css`; Quasar brand in `quasar.config.js` and `src/css/quasar.variables.scss`
+
+UI priority: Quasar props → Tailwind utilities → Quasar utility classes → scoped CSS last.
+
+## Key dependencies
 
 - **meilisearch** - JavaScript client for Meilisearch API
 - **@meilisearch/instant-meilisearch** - Adapter for Vue InstantSearch
@@ -110,89 +110,87 @@ Save and switch between multiple Meilisearch instances (development, staging, pr
 
 ## Architecture
 
-### Centralized Client Management
+### Headless core
 
-All Meilisearch client creation goes through `src/meili-core/stores/settings-store.js`, providing:
+Business logic lives in `src/meili-core/` (stores, services, pure utils). The Quasar pages are one UI on top of that core. Forkers can copy `meili-core` into another Vue app. See [`src/meili-core/README.md`](src/meili-core/README.md).
+
+### Client management
+
+All Meilisearch client creation goes through `src/meili-core/stores/settings-store.js`:
 
 - Automatic connection validation
-- Consistent on-demand client creation via store getter
-- Consistent error handling across all components
-- Safe instance switching with validation
+- On-demand client via store getter
+- `rawRequest` / Playground helpers for HTTP that matches n8n/Postman exports
+- Per-index search, display, and Playground drafts
 
-### Named Router Views
+### Routing
 
-The application uses dual router views for flexible layouts:
+Hash history SPA under `MainLayout`:
 
-- `main` - Primary page content
-- `side` - Contextual sidebar content
+- `/` Indexes
+- `/instances` Credentials and instance switcher
+- `/keys`, `/tasks`, `/dynamic-rules`
+- `/index-details/:uid?tab=documents|settings|playground|overview`
+- `/documents/:indexUid/:documentUid` full editor escape hatch
+- `/similar/:indexUid/:documentUid` when embedders/similar are available
 
-This allows pages to control both the main view and sidebar independently.
+### State management
 
-### State Management
+- **settings-store.js** - Instance credentials, last index/tab, per-index search/display/playground state, settings cache
+- **indexes-store / keys-store / tasks-store / dynamic-rules-store** - Domain lists and mutations
+- **preview-store.js** - Preview configurations (UI currently disabled)
 
-- **settings-store.js** (`src/meili-core/stores/`) — Instance credentials, active client, per-index search/display settings, and settings cache
-- **preview-store.js** — Preview configurations with tokenization support
-
-Document list field resolution and display defaults live in `src/meili-core/utils/display-settings.js` (headless; reusable by other UIs). See [`src/meili-core/README.md`](src/meili-core/README.md).
+Document list field resolution lives in `src/meili-core/utils/display-settings.js`.
 
 ---
 
 ## Deployment
 
-### Static Hosting
+### Static hosting
 
-- Build Command: `quasar build`
-- Output Directory: `dist/spa`
+- Build command: `npx quasar build` (or `npm run build`)
+- Output directory: `dist/spa`
 
-The application builds as a static SPA and can be hosted on any static file server (Nginx, Caddy, GitHub Pages, etc.).
+Host on any static file server (Nginx, Caddy, GitHub Pages, DigitalOcean Static Site, etc.). Hash routes avoid server rewrite requirements.
 
-### Native Applications
+### Native applications
 
-Quasar supports building for:
-
-- **Mobile**: iOS/Android via Cordova or Capacitor
-- **Desktop**: Windows/macOS/Linux via Electron
-
-See [Quasar documentation](https://quasar.dev) for platform-specific build instructions.
+Quasar supports Cordova/Capacitor and Electron builds. See [Quasar documentation](https://quasar.dev). Browser extension scaffolding exists under `src-bex/` but is not the primary product path.
 
 ## Customization
 
-Fork this repository and adapt to your needs. The codebase uses Vue 3 Composition API with Quasar components and Tailwind utilities.
+Fork this repository and adapt to your needs. Vue 3 Composition API, Quasar components, Tailwind utilities.
 
-Key customization points:
+Key points:
 
-- `src/meili-core/stores/settings-store.js` - Modify client management logic
-- `src/pages/` - Add new pages or modify existing ones
-- `src/components/` - Reusable components
-- `src/utils/notifications.js` - Centralized notification patterns
-- `generateChangelog.cjs` - Customize changelog generation logic
-
-**Styling**: Uses Tailwind CSS v4 for utility-first styling. All components use Tailwind utilities (e.g., `p-4`, `mt-2`) while retaining Quasar's Q\* components for complex UI elements.
+- `src/meili-core/` - Keep store/API contracts stable when embedding
+- `src/pages/` / `src/components/` - App shell and workspace UI
+- `src/utils/notifications.js` - Notify/Dialog helpers
+- `generateChangelog.cjs` - Changelog generation
 
 ---
 
-## Getting Started
+## Getting started
 
-### Adding Your First Instance
+### Adding your first instance
 
-1. Open the sidebar (hamburger menu, top-left or bottom-left)
-2. Enter instance details:
-   - **Label**: Descriptive name (e.g., "Production")
-   - **URL**: Meilisearch endpoint (https://example.com or http://localhost:7700)
-   - **API Key**: Master key or admin key with sufficient permissions
+1. Open **Instances** from the left drawer (or the connect panel if you are not connected yet)
+2. Enter:
+   - **Label**: Descriptive name (e.g. Production)
+   - **URL**: Meilisearch endpoint (`https://example.com` or `http://localhost:7700`)
+   - **API key**: Master or admin key with sufficient permissions
+3. Click **Add instance**
 
-3. Click "Add Instance"
+The connection is validated before the instance is saved.
 
-The connection is validated before the instance is saved. If validation fails, check your URL and API key.
+### Required permissions
 
-### Required Permissions
-
-Minimum permissions for basic functionality:
+Minimum for basic read paths:
 
 - `indexes.get`
 - `documents.get`
 
-For full functionality (creating indexes, managing keys, etc.), use a master key or admin key. Create more restrictive keys once configuration is complete.
+For full functionality (creating indexes, managing keys, settings writes), use a master key or admin key. Create more restrictive keys once configuration is complete.
 
 ### Endpoints/Methods used
 
@@ -200,13 +198,9 @@ For full functionality (creating indexes, managing keys, etc.), use a master key
 
 ---
 
-## Home page / Index list page
+## Indexes home
 
-### Data shown in the list
-
-Here you will see a list of your indexes with their created and updated time stamps, a button to examine each, and a button to delete each.
-
-The delete icon will give a warning that needs confirmation before it sends the delete call.
+List of indexes with created/updated timestamps, document counts, attribute counts when available, **Open** into the workspace, and delete with confirmation. **Continue** resumes the last index and tab.
 
 ### Endpoints/Methods used
 
@@ -216,51 +210,33 @@ The delete icon will give a warning that needs confirmation before it sends the 
 
 ---
 
-## Index detail page
+## Index detail workspace
 
-The index detail page uses three tabs: **Documents** (default), **Overview**, and **Settings**. Tab choice is persisted per index in local search state.
+Tabs: **Documents** (default), **Settings**, **Playground**, **Overview**. Tab choice syncs to `?tab=` and is persisted per index.
 
-### Overview tab
+### Overview
 
-- Count of records in the index
-- Primary key of the index if set
-- Indexing true/false
+- Document count, primary key, indexing flag
 - Field distribution table
-- Paginated fields metadata table (when the server exposes `/fields`)
+- Paginated fields metadata when the server exposes `/fields`
 
-### Settings tab
+### Settings
 
-Review and update all index settings. The settings object is displayed in full (and in real time) if you expand the **Raw Settings JSON** section at the top. This is a read-only view, but may be easier to understand at first than the full form.
+Review and update index settings. Expand **Raw Settings JSON** for a live object dump. Use section jump into Search / Relevancy / Performance / Advanced / AI. Changes stay local until **Submit**.
 
-Please follow the link there for the settings documentation — each field has its own purpose that needs to be understood.
+### Documents
 
-While the form is stored in your local memory, it is not pushed to your Meilisearch instance until you press **Submit**, for safety. Submitting also refreshes the in-memory settings cache used by the Documents tab filters.
+InstantSearch browser:
 
-### Documents tab
+- Query, sort, filters (advanced / LLM controls collapsed by default)
+- Display menu: compact / detailed / table, list fields, thumbnails
+- Click a hit to open the JSON side panel; full editor via **Open full editor** or `/documents/...`
+- Fetch by IDs when supported; **New** creates via the full editor route
+- Diagnostics: **Open in Playground** with an effective search body when available
 
-Full-height document browser with Vue InstantSearch:
+### Playground
 
-- **Search toolbar** — query, sort, hybrid/diagnostic options (version-gated), and saved search state
-- **Display menu** — compact / detailed / table view, optional thumbnail field, custom list fields and column count, reset to index defaults
-- **Resizable filters panel** — facet refinements for `filterableAttributes` (hidden/shown via toolbar; width persisted per index)
-- **Fetch by IDs** — batch document lookup when the server supports it
-- **New** — create an example document (not the recommended bulk-ingest path)
-
-#### View modes
-
-| Mode | Behavior |
-|------|----------|
-| **Compact** (default) | Shows a short preview (~4 fields) per card with expand for the rest; uses index `displayedAttributes` or field distribution when unset |
-| **Detailed** | Shows all resolved list fields on each card; when `displayedAttributes` is `["*"]` and no custom list is set, every field on the document is shown |
-| **Table** | Dense `q-table` with primary key plus up to 8 list columns and an edit action |
-
-List field source order: custom `listFields` → index `displayedAttributes` → field distribution (wildcard `*` uses distribution keys in compact/table, all keys per hit in detailed).
-
-#### Result cards / table rows
-
-Each hit shows a title from `name`, `title`, `label`, or the primary key; optional thumbnail; field values (objects as JSON strings); **Edit** to open the JSON editor; **Similar** when embedders are configured and the server supports similar search.
-
-Settings changes on the Settings tab update facet widgets on Documents without a full page reload.
+Craft `GET`/`POST`/… requests scoped to the current index, Send, inspect status/timing/JSON, copy redacted curl (default) or with-key / HTTP / n8n JSON. Seed from Documents hit or diagnostics. See [`docs/workspace-ux.md`](docs/workspace-ux.md).
 
 ### Endpoints/Methods used
 
@@ -270,19 +246,16 @@ Settings changes on the Settings tab update facet widgets on Documents without a
 - [fetchPrimaryKey](https://github.com/meilisearch/meilisearch-js#get-primary-key-of-an-index)
 - [updateSettings](https://github.com/meilisearch/meilisearch-js#update-settings)
 - [waitForTask](https://github.com/meilisearch/meilisearch-js#using-the-index)
+- Raw `fetch` via Playground / `rawRequest` for HTTP parity with exports
 
 ---
 
 ## Document detail page
 
-### Overview
-
-The document detail page uses a clean text-mode JSON editor with syntax highlighting and validation. Edit documents as raw JSON with real-time error checking.
+Full-page JSON editor escape hatch (text mode). Prefer the Documents side panel for quick inspection.
 
 ### Endpoints/Methods used
 
-- [index](https://github.com/meilisearch/meilisearch-js#using-the-index-object-1)
-- [fetchPrimaryKey](https://github.com/meilisearch/meilisearch-js#get-primary-key-of-an-index)
 - [getDocument](https://github.com/meilisearch/meilisearch-js#get-one-document)
 - [addDocuments](https://github.com/meilisearch/meilisearch-js#add-or-replace-multiple-documents)
 - [waitForTask](https://github.com/meilisearch/meilisearch-js#using-the-index)
@@ -291,15 +264,9 @@ The document detail page uses a clean text-mode JSON editor with syntax highligh
 
 ## Keys page
 
-### Overview
+Review keys, create with actions/indexes, update and delete. Prefer a scoped admin key over long-term master key use in the UI.
 
-Similar to the settings tab, you can review the entire response of the `getKeys` endpoint by clicking the "Raw Keys JSON" button.
-
-Below that is the "New Key Form" - all fields are required. The list of available actions is static, while the list of indexes is dynamic based on your key's permissions to use the getIndexes endpoints. Wildcards are not allowed here, but can be used via direct api calls.
-
-**_Please review [the Keys documentation](https://docs.meilisearch.com/reference/api/keys.html) to fully understand the available settings._**
-
-The first thing you should do with your master key is create an admin key with the minimum priveleges necessary!
+**Please review [the Keys documentation](https://docs.meilisearch.com/reference/api/keys.html).**
 
 ### Endpoints/Methods used
 
@@ -307,17 +274,12 @@ The first thing you should do with your master key is create an admin key with t
 - [updateKey](https://github.com/meilisearch/meilisearch-js#update-a-key)
 - [deleteKey](https://github.com/meilisearch/meilisearch-js#delete-a-key)
 - [createKey](https://github.com/meilisearch/meilisearch-js#create-a-key)
-- [getRawIndexes](https://github.com/meilisearch/meilisearch-js#get-all-indexes)
 
 ---
 
 ## Tasks page
 
-### Overview
-
-The tasks page shows you a paginated, sortable, searchable table of all of the tasks as of the page loading. This table is limited to the most recent 1000 tasks.
-
-This page is a good way to review if an index is busy, or if a particular task failed/succeeded.
+Paginated, sortable, searchable table of recent tasks (capped around the most recent 1000). Useful to see whether an index is busy or a task failed.
 
 ### Endpoints/Methods used
 
@@ -325,30 +287,6 @@ This page is a good way to review if an index is busy, or if a particular task f
 
 ---
 
-## Preview Mode
+## Contributing
 
-A more detail oriented preview with the eventual goal of being sharable.
-Save as many preview configurations as you like and switch the index/instance powering them independently.
-
-Settings currently available:
-
-- Name (For load/save key locally)
-- Pagination
-- Pagination Size
-- Show Refinements
-- Show Clear refinements
-- Attribute based options:
-  - **_You can manually enter options by typing and pressing enter_**
-    - **eg `attributeName.subProperty` is valid assuming subProperty exists**
-  - Sortable Attributes
-    - Auto generate asc and desc sort options based on attributes entered here
-  - Facet/Filter Attributes
-    - Auto generate filters based on attributes
-      - Currently just `refinement-list` but the goal is to have more options per attribute for other filter types
-  - Image Attributes
-    - Treat the entered attributes as src/href for image(s) for each result
-  - Heading Attributes
-    - Show the attributes content above the content as H6's for each result
-      - More control over this is on the road map
-  - Description Attributes
-    - Show the attributes content below the heading for each result
+Issues and PRs are welcome. Keep changes focused; prefer extending `meili-core` carefully over breaking store contracts. Run `npm run lint` before opening a PR. Manual acceptance ideas against a real index are listed in [`docs/workspace-ux.md`](docs/workspace-ux.md) and the UX overhaul plan checklist (Continue, side panel Esc/copy, settings Submit, Playground redacted curl, drawer Instances/Keys/Tasks/Rules).

--- a/README.md
+++ b/README.md
@@ -10,22 +10,37 @@ Credentials never leave the browser: instance URLs and API keys are stored in `l
 ## Docs
 
 - Workspace UX (index-first, Playground, side panel): [`docs/workspace-ux.md`](docs/workspace-ux.md)
+- Themes (picker, catalog, contrast): [`docs/themes.md`](docs/themes.md)
 - Reuse/fork/embed playbook: [`docs/reuse-and-embedding.md`](docs/reuse-and-embedding.md)
 - Headless core (copy-paste): [`src/meili-core/README.md`](src/meili-core/README.md)
 - Dynamic search rules: [`docs/dynamic-search-rules.md`](docs/dynamic-search-rules.md)
 - Release readiness summary: [`docs/release-readiness-1.42.md`](docs/release-readiness-1.42.md)
 - Dual-version QA checklist: [`docs/qa-checklist-1.11-1.42.md`](docs/qa-checklist-1.11-1.42.md)
 - GitHub release draft: [`RELEASE_DRAFT_1.42.md`](RELEASE_DRAFT_1.42.md)
+- Playwright shell screenshots (mobile/desktop review): [`docs/e2e-screenshots.md`](docs/e2e-screenshots.md)
 
 ## Quick start
 
 ```bash
 npm install
 npm run lint
-npx quasar dev
+npm run check:themes
+npm run dev
 ```
 
-The Quasar CLI is available via `npx` (or `@quasar/cli` if you prefer a global install). Dev server defaults to the Quasar/Vite port (usually `http://localhost:9000/`). Hash routing is used so the SPA works on static hosts such as `meili-manager.weeumson.com`.
+`npm run dev` runs `quasar dev` (also fine via `npx quasar`). Dev server defaults to the Quasar/Vite port (usually `http://localhost:9000/`). Hash routing is used so the SPA works on static hosts such as `meili-manager.weeumson.com`.
+
+### Screenshot review (Playwright)
+
+One-time: `npx playwright install chromium`. Then with the app on `:9000` (or let Playwright start `npm run dev`):
+
+```bash
+npm run test:e2e
+# or
+npm run review:screenshots
+```
+
+PNGs land in `tests/e2e/screenshots/` (gitignored). No Meili API keys required; specs capture the unconnected shell. Details: [`docs/e2e-screenshots.md`](docs/e2e-screenshots.md).
 
 ### Production build
 
@@ -47,6 +62,7 @@ Generates `changelog.json` with versioned entries grouped by ISO week.
 
 ```bash
 npm run lint
+npm run check:themes
 npm run format
 ```
 
@@ -89,11 +105,11 @@ Preview routes remain in the tree but are disabled in the router. Do not revive 
 
 ## Theme
 
-Dark Weeumson docs-style shell by default:
+Named presets from a single catalog (`src/themes/catalog.js`): Weeumson Dark (default), Weeumson Light, Slate Dark, Slate Light, High Contrast. Header palette picker; WCAG AA checked via `npm run check:themes`. See [`docs/themes.md`](docs/themes.md).
 
 - IBM Plex Sans
-- Primary `#b85538`, elevated page surfaces, square cards/buttons
-- Tailwind v4 theme tokens in `src/css/tailwind.css`; Quasar brand in `quasar.config.js` and `src/css/quasar.variables.scss`
+- Runtime CSS vars + Quasar `setCssVar` from the catalog (no per-theme CSS palettes)
+- Build-time Quasar brand defaults match Weeumson Dark
 
 UI priority: Quasar props → Tailwind utilities → Quasar utility classes → scoped CSS last.
 

--- a/docs/dynamic-search-rules.md
+++ b/docs/dynamic-search-rules.md
@@ -5,7 +5,7 @@ This app exposes Meilisearch **Dynamic Search Rules** when the server supports t
 ## UI entry
 
 - Header tab **Dynamic rules** → route `/dynamic-rules`.
-- Requires saved Meilisearch URL + API key in the sidebar (same as other pages).
+- Requires saved Meilisearch URL + API key on the Instances page (same as other pages).
 
 ## Capabilities surfaced
 

--- a/docs/e2e-screenshots.md
+++ b/docs/e2e-screenshots.md
@@ -1,0 +1,43 @@
+# Playwright screenshot review (meili-manager)
+
+Minimal smoke screenshots so agents can review mobile and desktop shell UI without a live Meilisearch or real API keys.
+
+## One-time setup
+
+```bash
+npm install
+npx playwright install chromium
+```
+
+Chromium is not assumed to be installed globally.
+
+## Run
+
+Dev server defaults to `http://localhost:9000/`. Playwright reuses an existing server when available (`reuseExistingServer`).
+
+```bash
+# Start the app if nothing is already on :9000
+npm run dev
+
+# Write screenshots (desktop 1280x800 + mobile 390x844)
+npm run test:e2e
+
+# Same suite (tagged @visual)
+npm run review:screenshots
+```
+
+Hash routes are used (`/#/`, `/#/instances`). Specs clear of credentials: empty browser storage shows the **Connect to Meilisearch** / **Not connected** shell. Do not commit secrets.
+
+## Output (gitignored)
+
+| Path | Purpose |
+|------|---------|
+| `tests/e2e/screenshots/` | PNGs named `{page}-{desktop\|mobile}.png` (plus `home-drawer-mobile.png`) |
+| `test-results/` | Playwright failure artifacts |
+| `playwright-report/` | HTML report if enabled |
+
+Open the screenshot folder after a run and inspect the PNGs before treating UI work as done.
+
+## Limitations
+
+Without saved instance credentials, captures show the connect gate and Instances form, not a live index/workspace. That is intentional for CI and local review without API keys.

--- a/docs/reuse-and-embedding.md
+++ b/docs/reuse-and-embedding.md
@@ -7,7 +7,7 @@ This guide focuses on making `meili-manager` easy to fork, partially embed, or p
 ## 1) Full Fork (quickest)
 
 - Fork the repo and keep app structure intact.
-- Rebrand app shell and sidebar labels first.
+- Rebrand app shell and drawer nav labels first.
 - Keep `src/meili-core/stores/settings-store.js` unchanged initially to avoid auth/session regressions.
 
 Best when you want a standalone admin app quickly.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,37 @@
+# Themes
+
+Named complete presets. Pick a look in the header palette menu. Each look maps to Quasar dark or light under the hood.
+
+## Switch theme
+
+1. Open the app header **Theme** (palette) menu.
+2. Choose Weeumson Dark, Weeumson Light, Slate Dark, Slate Light, or High Contrast.
+3. Choice persists in Pinia (`themeId`) and `localStorage` key `meili-manager-theme`.
+
+Legacy `darkMode: false` migrates to `weeumson-light`; otherwise default is `weeumson-dark`.
+
+## Add a theme
+
+1. Copy a block in [`src/themes/catalog.js`](../src/themes/catalog.js).
+2. Set `id`, `label`, `description`, `isDark`, and every key in `TOKEN_KEYS`.
+3. Add the same `id` to `THEME_IDS` in [`src/meili-core/stores/settings-store.js`](../src/meili-core/stores/settings-store.js) (and to `LIGHT_THEME_IDS` if `isDark` is false).
+4. Run `npm run check:themes` and fix any AA failures.
+5. The picker and `applyTheme` pick it up automatically. No per-theme CSS files.
+
+## Tokens
+
+Required keys (`TOKEN_KEYS`): `page`, `pageElevated`, `border`, `text`, `textMuted`, `primary`, `secondary`, `accent`, `focusRing`, `onPrimary`, `positive`, `negative`, `info`, `warning`.
+
+Runtime CSS vars: `--color-page`, `--color-page-elevated`, and so on. Vue uses token utilities only (`bg-page`, `text-text-muted`, `border-border`, `text-on-primary`).
+
+## Portable unit (for later Weeumson PWAs)
+
+Copy **`catalog.js` + `applyTheme.js` + `TOKEN_KEYS`**. Each app can keep fonts and extra tokens local. Do not maintain duplicate hex palettes in CSS.
+
+## Contrast
+
+```bash
+npm run check:themes
+```
+
+Checks fixed AA pairs for every theme (body/muted text, on-primary, primary vs page, focus, border). Pair list lives in `scripts/check-theme-contrast.mjs`.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -24,6 +24,8 @@ Required keys (`TOKEN_KEYS`): `page`, `pageElevated`, `border`, `text`, `textMut
 
 Runtime CSS vars: `--color-page`, `--color-page-elevated`, and so on. Vue uses token utilities only (`bg-page`, `text-text-muted`, `border-border`, `text-on-primary`).
 
+Picker swatches (via `getThemeSwatches` / `SWATCH_TOKEN_KEYS`): `page`, `pageElevated`, `primary`, `text`.
+
 ## Portable unit (for later Weeumson PWAs)
 
 Copy **`catalog.js` + `applyTheme.js` + `TOKEN_KEYS`**. Each app can keep fonts and extra tokens local. Do not maintain duplicate hex palettes in CSS.

--- a/docs/workspace-ux.md
+++ b/docs/workspace-ux.md
@@ -7,7 +7,7 @@ Meili-Manager is open source. This note describes the current shell and index-fi
 - Persistent left drawer: Indexes, Instances, Keys, Tasks, Dynamic rules.
 - Header context chip shows active instance label, host, and current index when you are inside an index route.
 - Unconnected state shows a connect panel that links to **Instances** instead of blanking the app behind a hard banner.
-- Theme tokens follow a Weeumson docs-style dark shell (IBM Plex Sans, terracotta primary, square elevated surfaces). Values live in `src/css/tailwind.css`, `src/css/app.scss`, and `src/css/quasar.variables.scss`.
+- Themes are named presets from [`src/themes/catalog.js`](../src/themes/catalog.js) (Weeumson Dark default, plus Light / Slate / High Contrast). Runtime CSS vars and Quasar `setCssVar` come from the catalog; see [`docs/themes.md`](themes.md). Shell uses IBM Plex Sans and square elevated surfaces.
 
 ## Indexes home
 

--- a/docs/workspace-ux.md
+++ b/docs/workspace-ux.md
@@ -1,0 +1,55 @@
+# Index workspace UX
+
+Meili-Manager is open source. This note describes the current shell and index-first workflow so contributors and self-hosters know what to expect.
+
+## Shell
+
+- Persistent left drawer: Indexes, Instances, Keys, Tasks, Dynamic rules.
+- Header context chip shows active instance label, host, and current index when you are inside an index route.
+- Unconnected state shows a connect panel that links to **Instances** instead of blanking the app behind a hard banner.
+- Theme tokens follow a Weeumson docs-style dark shell (IBM Plex Sans, terracotta primary, square elevated surfaces). Values live in `src/css/tailwind.css`, `src/css/app.scss`, and `src/css/quasar.variables.scss`.
+
+## Indexes home
+
+- Cluster stats and index list use bordered elevated cards.
+- **Continue** resumes the last index and last tab (`lastIndexUid` / `lastIndexTab` in `settings-store`).
+- Create index stays a dialog.
+
+## Index workspace (`/index-details/:uid`)
+
+Peer tabs (query `?tab=` is shareable):
+
+| Tab | Role |
+| --- | --- |
+| **Documents** | InstantSearch browser; click a hit for a JSON side panel |
+| **Settings** | Full settings form with section jump and sticky Submit |
+| **Playground** | Raw HTTP request builder with curl / HTTP / n8n exports |
+| **Overview** | Stats, field distribution, fields metadata |
+
+### Documents side panel
+
+- Read-only JSON by default (`vue3-ts-jsoneditor` view mode).
+- Actions: Copy JSON, Edit (toggle writable), Open in Playground, Open full editor, Similar (when available).
+- Full `/documents/:index/:id` page remains the deep-link escape hatch.
+- Shortcuts: `Esc` closes the panel; `/` focuses the search query when focus is not in an input.
+
+### Settings
+
+- Nested category tabs kept (Search, Relevancy, Performance, Advanced, AI).
+- Jump buttons skip hunting; sticky bar shows unsaved state; Submit remains explicit (no auto-save).
+
+### Playground
+
+- Builds live calls against the active instance (raw `fetch`, not InstantSearch).
+- Export strip is available before Send: redacted Bearer curl by default; secondary copies include the key for local n8n/Postman.
+- Documents diagnostics and hit panel can seed search or get-document requests.
+- Destructive methods require an explicit confirm toggle before Send.
+- Shortcut: `Ctrl/Cmd+Enter` sends.
+
+Helpers: `src/meili-core/utils/playground-request.js`. Drafts persist per index in `settings-store.indexPlaygroundState`.
+
+## Contribution notes
+
+- Prefer Quasar component props, then Tailwind utilities, then Quasar utility classes, then scoped CSS.
+- Keep `src/meili-core/` store/API contracts stable; extend carefully.
+- Do not commit secrets or `.env` files. Instance keys stay in browser `localStorage` via Pinia persisted state.

--- a/docs/workspace-ux.md
+++ b/docs/workspace-ux.md
@@ -42,6 +42,7 @@ Peer tabs (query `?tab=` is shareable):
 
 - Builds live calls against the active instance (raw `fetch`, not InstantSearch).
 - Export strip is available before Send: redacted Bearer curl by default; secondary copies include the key for local n8n/Postman.
+- **Copy n8n JSON** / **n8n + key** copy a canvas-pasteable workflow snippet (one `n8n-nodes-base.httpRequest` node, typeVersion 4.2). Paste with Ctrl/Cmd+V on the n8n canvas. Redacted uses `Bearer REDACTED`; **n8n + key** embeds the real key in the Authorization header. Node defaults: `options.timeout` 30000 ms, `retryOnFail` with `maxTries` 3 and `waitBetweenTries` 1000 ms. JSON body uses `contentType: json` + `specifyBody: json` + string `jsonBody` (Meili search/documents). Content-Type is left to the HTTP Request node; only Authorization is set as a header.
 - Documents diagnostics and hit panel can seed search or get-document requests.
 - Destructive methods require an explicit confirm toggle before Send.
 - Shortcut: `Ctrl/Cmd+Enter` sends.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "vue3-ts-jsoneditor": "^3.1.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@quasar/app-vite": "2.4.1",
         "@tailwindcss/postcss": "^4.1.16",
         "@tailwindcss/vite": "^4.0.0",
@@ -1838,6 +1839,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -3344,6 +3361,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.16",
@@ -8696,6 +8773,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.14",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "quasar dev",
     "build": "quasar build",
     "build-changelog": "node ./generateChangelog.cjs",
     "deploy": "echo \"Build dist/spa and deploy to your static host\"",
     "lint": "eslint --ext .js,.vue ./",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "echo \"No test specified\" && exit 0"
+    "check:themes": "node scripts/check-theme-contrast.mjs",
+    "test": "echo \"No test specified\" && exit 0",
   },
   "dependencies": {
     "@meilisearch/instant-meilisearch": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meili-manager",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Quasar app to manage multiple Meilisearch instances",
   "productName": "MeiliSearch Manager",
   "author": "bwilliamson55@github.com",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
     "check:themes": "node scripts/check-theme-contrast.mjs",
     "test": "echo \"No test specified\" && exit 0",
+    "test:e2e": "playwright test",
+    "review:screenshots": "playwright test --grep @visual"
   },
   "dependencies": {
     "@meilisearch/instant-meilisearch": "^0.31.1",
@@ -34,6 +36,7 @@
     "vue3-ts-jsoneditor": "^3.1.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@quasar/app-vite": "2.4.1",
     "@tailwindcss/postcss": "^4.1.16",
     "@tailwindcss/vite": "^4.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/** Override when Quasar binds the next free port (e.g. 9001). */
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:9000'
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  fullyParallel: true,
+  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    // Reuses an already-running Quasar dev server when not in CI.
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      name: 'mobile',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+})

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -27,7 +27,7 @@ export default configure(function (/* ctx */) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli/boot-files
-    boot: ["instant-search"],
+    boot: ["theme", "instant-search"],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ["tailwind.css", "app.scss"],
@@ -80,16 +80,17 @@ export default configure(function (/* ctx */) {
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework
     framework: {
       config: {
+        // Build-time defaults match weeumson-dark; runtime applyTheme setCssVar owns live brand.
         brand: {
           primary: "#b85538",
-          secondary: "#6f7a68",
+          secondary: "#8a9480",
           accent: "#b8956c",
-          dark: "#2c2824",
+          dark: "#232019",
           "dark-page": "#1a1714",
-          positive: "#5a7a52",
-          negative: "#a84335",
-          info: "#6b8b9e",
-          warning: "#c98838",
+          positive: "#7a9a70",
+          negative: "#d46a5c",
+          info: "#7a9eb0",
+          warning: "#d4a05a",
         },
       },
 

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -34,16 +34,8 @@ export default configure(function (/* ctx */) {
 
     // https://github.com/quasarframework/quasar/tree/dev/extras
     extras: [
-      // 'ionicons-v4',
-      // 'mdi-v5',
-      // 'fontawesome-v6',
-      // 'eva-icons',
-      // 'themify',
-      // 'line-awesome',
-      // 'roboto-font-latin-ext', // this or either 'roboto-font', NEVER both!
-
-      "roboto-font", // optional, you are not bound to it
-      "material-icons", // optional, you are not bound to it
+      // IBM Plex Sans is loaded via Google Fonts in app.scss (no roboto-font).
+      "material-icons",
     ],
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#build
@@ -87,19 +79,20 @@ export default configure(function (/* ctx */) {
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework
     framework: {
-      config: {},
+      config: {
+        brand: {
+          primary: "#b85538",
+          secondary: "#6f7a68",
+          accent: "#b8956c",
+          dark: "#2c2824",
+          "dark-page": "#1a1714",
+          positive: "#5a7a52",
+          negative: "#a84335",
+          info: "#6b8b9e",
+          warning: "#c98838",
+        },
+      },
 
-      // iconSet: 'material-icons', // Quasar icon set
-      // lang: 'en-US', // Quasar language pack
-
-      // For special cases outside of where the auto-import strategy can have an impact
-      // (like functional components as one of the examples),
-      // you can manually specify Quasar components/directives to be available everywhere:
-      //
-      // components: [],
-      // directives: [],
-
-      // Quasar plugins
       plugins: ["Notify", "Dark", "Dialog"],
     },
 

--- a/scripts/check-theme-contrast.mjs
+++ b/scripts/check-theme-contrast.mjs
@@ -42,10 +42,14 @@ const PAIRS = [
   ["text / page", "text", "page", 4.5],
   ["textMuted / page", "textMuted", "page", 4.5],
   ["textMuted / pageElevated", "textMuted", "pageElevated", 4.5],
+  // Filled primary buttons (Send): must never be white-on-yellow.
   ["onPrimary / primary", "onPrimary", "primary", 4.5],
+  // Outline primary labels / borders on page chrome.
   ["primary / page (non-text)", "primary", "page", 3],
+  ["primary / pageElevated (non-text)", "primary", "pageElevated", 3],
   ["focusRing / page", "focusRing", "page", 3],
   ["border / page", "border", "page", 3],
+  ["border / pageElevated", "border", "pageElevated", 3],
 ];
 
 let failed = 0;

--- a/scripts/check-theme-contrast.mjs
+++ b/scripts/check-theme-contrast.mjs
@@ -1,0 +1,84 @@
+/**
+ * WCAG AA contrast checks against src/themes/catalog.js (single source of truth).
+ * Pair list lives here so docs do not go stale.
+ *
+ * Run: npm run check:themes
+ */
+
+import {
+  TOKEN_KEYS,
+  themes,
+} from "../src/themes/catalog.js";
+
+function relativeLuminance(hex) {
+  const raw = hex.replace("#", "");
+  const full =
+    raw.length === 3
+      ? raw
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : raw;
+  const n = parseInt(full, 16);
+  const channel = (v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const r = channel((n >> 16) & 255);
+  const g = channel((n >> 8) & 255);
+  const b = channel(n & 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(a, b) {
+  const L1 = relativeLuminance(a);
+  const L2 = relativeLuminance(b);
+  const [hi, lo] = L1 > L2 ? [L1, L2] : [L2, L1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Fixed AA pairs: [label, fgKey, bgKey, minimum] */
+const PAIRS = [
+  ["text / page", "text", "page", 4.5],
+  ["textMuted / page", "textMuted", "page", 4.5],
+  ["textMuted / pageElevated", "textMuted", "pageElevated", 4.5],
+  ["onPrimary / primary", "onPrimary", "primary", 4.5],
+  ["primary / page (non-text)", "primary", "page", 3],
+  ["focusRing / page", "focusRing", "page", 3],
+  ["border / page", "border", "page", 3],
+];
+
+let failed = 0;
+
+for (const theme of Object.values(themes)) {
+  for (const key of TOKEN_KEYS) {
+    if (!theme.tokens[key]) {
+      console.error(`FAIL ${theme.id}: missing token "${key}"`);
+      failed += 1;
+    }
+  }
+
+  for (const [label, fgKey, bgKey, min] of PAIRS) {
+    const fg = theme.tokens[fgKey];
+    const bg = theme.tokens[bgKey];
+    if (!fg || !bg) continue;
+    const ratio = contrastRatio(fg, bg);
+    if (ratio < min) {
+      console.error(
+        `FAIL ${theme.id}: ${label} = ${ratio.toFixed(2)}:1 (need ≥ ${min}:1) [${fg} on ${bg}]`,
+      );
+      failed += 1;
+    } else {
+      console.log(
+        `OK   ${theme.id}: ${label} = ${ratio.toFixed(2)}:1`,
+      );
+    }
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} contrast check(s) failed.`);
+  process.exit(1);
+}
+
+console.log(`\nAll themes pass AA pairs (${Object.keys(themes).length} themes).`);

--- a/src/boot/theme.js
+++ b/src/boot/theme.js
@@ -1,0 +1,7 @@
+import { boot } from "quasar/wrappers";
+import { applyTheme, readStoredThemeId } from "src/themes/applyTheme";
+
+// Same apply path as MainLayout / settings store (anti-FOUC after first paint fallback).
+export default boot(() => {
+  applyTheme(readStoredThemeId());
+});

--- a/src/components/ApiKeyForm.vue
+++ b/src/components/ApiKeyForm.vue
@@ -21,8 +21,8 @@
           lazy-rules
         />
         <div class="flex flex-col md:flex-row justify-evenly gap-4">
-          <div class="bg-gray-100 dark:bg-gray-800 p-4 rounded flex-1">
-            <div class="font-semibold mb-2">Granted Actions:</div>
+          <div class="bg-page p-4 border border-border flex-1">
+            <div class="font-semibold mb-2 text-text">Granted Actions:</div>
             <q-select
               filled
               v-model="newKeyObj.actions"
@@ -40,8 +40,8 @@
               @filter-abort="abortFilterFn"
             />
           </div>
-          <div class="bg-gray-100 dark:bg-gray-800 p-4 rounded flex-1">
-            <div class="font-semibold mb-2">Granted Indexes:</div>
+          <div class="bg-page p-4 border border-border flex-1">
+            <div class="font-semibold mb-2 text-text">Granted Indexes:</div>
             <q-select
               filled
               v-model="newKeyObj.indexes"

--- a/src/components/ApiKeyForm.vue
+++ b/src/components/ApiKeyForm.vue
@@ -26,7 +26,7 @@
         />
         <div class="flex flex-col md:flex-row justify-evenly gap-4">
           <div class="bg-page p-4 border border-border flex-1">
-            <div class="font-semibold mb-1 text-text">Granted actions</div>
+            <div class="mm-section-title mb-1">Granted actions</div>
             <p class="text-caption text-text-muted mb-2">
               See Meilisearch keys docs for action meanings. Use * for all
               permissions.
@@ -51,7 +51,7 @@
             />
           </div>
           <div class="bg-page p-4 border border-border flex-1">
-            <div class="font-semibold mb-2 text-text">Granted indexes</div>
+            <div class="mm-section-title mb-2">Granted indexes</div>
             <q-select
               outlined
               dense

--- a/src/components/ApiKeyForm.vue
+++ b/src/components/ApiKeyForm.vue
@@ -1,33 +1,43 @@
 <template>
   <div class="flex flex-wrap gap-2 p-2">
-    <q-card class="w-full p-6" flat>
-      <p class="text-center font-bold mb-4">
+    <q-card class="w-full p-6" flat square>
+      <p class="text-center font-bold mb-4 text-text">
         {{ newKeyObj.name }}
       </p>
       <q-form @submit="onSubmit" @reset="onReset" class="space-y-4">
         <q-input
-          filled
+          outlined
+          dense
+          square
           v-model="newKeyObj.name"
-          label="The Keys name"
+          label="Key name"
           hint="Something descriptive"
           lazy-rules
           :rules="[(val) => (val && val.length > 0) || 'Please type something']"
         />
         <q-input
-          filled
+          outlined
+          dense
+          square
           v-model="newKeyObj.description"
-          label="The Keys Description"
+          label="Description"
           hint="Something descriptive"
           lazy-rules
         />
         <div class="flex flex-col md:flex-row justify-evenly gap-4">
           <div class="bg-page p-4 border border-border flex-1">
-            <div class="font-semibold mb-2 text-text">Granted Actions:</div>
+            <div class="font-semibold mb-1 text-text">Granted actions</div>
+            <p class="text-caption text-text-muted mb-2">
+              See Meilisearch keys docs for action meanings. Use * for all
+              permissions.
+            </p>
             <q-select
-              filled
+              outlined
+              dense
+              square
               v-model="newKeyObj.actions"
-              label="Searchable Actions"
-              hint="A list of strings. Press enter to add values you type."
+              label="Actions"
+              hint="Press enter to add values you type"
               use-input
               use-chips
               multiple
@@ -41,12 +51,14 @@
             />
           </div>
           <div class="bg-page p-4 border border-border flex-1">
-            <div class="font-semibold mb-2 text-text">Granted Indexes:</div>
+            <div class="font-semibold mb-2 text-text">Granted indexes</div>
             <q-select
-              filled
+              outlined
+              dense
+              square
               v-model="newKeyObj.indexes"
-              label="Searchable Indexes"
-              hint="A list of strings. Press enter to add values you type."
+              label="Indexes"
+              hint="Press enter to add values you type"
               use-input
               use-chips
               multiple
@@ -61,15 +73,21 @@
         </div>
         <div class="flex flex-col md:flex-row justify-evenly gap-4">
           <q-input
-            filled
+            outlined
+            dense
+            square
             v-model="newKeyObj.expiresAt"
-            label="Expires At"
-            hint="Required but can be null"
+            label="Expires at"
+            hint="Leave empty for no expiration"
             clearable
             class="flex-1"
           >
             <template v-slot:prepend>
-              <q-icon name="event" class="cursor-pointer">
+              <q-icon
+                name="event"
+                class="cursor-pointer"
+                aria-label="Pick expiration date"
+              >
                 <q-popup-proxy
                   cover
                   transition-show="scale"
@@ -80,7 +98,14 @@
                     mask="YYYY-MM-DD HH:mm:ss"
                   >
                     <div class="flex items-center justify-end">
-                      <q-btn v-close-popup label="Close" color="primary" flat />
+                      <q-btn
+                        v-close-popup
+                        label="Close"
+                        color="primary"
+                        flat
+                        square
+                        no-caps
+                      />
                     </div>
                   </q-date>
                 </q-popup-proxy>
@@ -88,7 +113,11 @@
             </template>
 
             <template v-slot:append>
-              <q-icon name="access_time" class="cursor-pointer">
+              <q-icon
+                name="access_time"
+                class="cursor-pointer"
+                aria-label="Pick expiration time"
+              >
                 <q-popup-proxy
                   cover
                   transition-show="scale"
@@ -100,7 +129,14 @@
                     format24h
                   >
                     <div class="flex items-center justify-end">
-                      <q-btn v-close-popup label="Close" color="primary" flat />
+                      <q-btn
+                        v-close-popup
+                        label="Close"
+                        color="primary"
+                        flat
+                        square
+                        no-caps
+                      />
                     </div>
                   </q-time>
                 </q-popup-proxy>
@@ -109,7 +145,14 @@
           </q-input>
         </div>
         <div>
-          <q-btn label="Save" type="submit" color="primary" />
+          <q-btn
+            unelevated
+            square
+            no-caps
+            label="Create key"
+            type="submit"
+            color="primary"
+          />
         </div>
       </q-form>
     </q-card>

--- a/src/components/IndexDetailTabs.vue
+++ b/src/components/IndexDetailTabs.vue
@@ -14,6 +14,7 @@
         indicator-color="primary"
         align="left"
         narrow-indicator
+        aria-label="Index sections"
       >
         <q-tab name="documents" label="Documents" icon="description" no-caps />
         <q-tab name="settings" label="Settings" icon="settings" no-caps />

--- a/src/components/IndexDetailTabs.vue
+++ b/src/components/IndexDetailTabs.vue
@@ -9,7 +9,7 @@
       <q-tabs
         v-model="tabModel"
         dense
-        class="text-text-muted flex-shrink-0"
+        class="mm-index-tabs flex-shrink-0"
         active-color="primary"
         indicator-color="primary"
         align="left"

--- a/src/components/IndexDetailTabs.vue
+++ b/src/components/IndexDetailTabs.vue
@@ -1,18 +1,24 @@
 <template>
   <div class="flex flex-col flex-1 min-h-0 w-full">
-    <q-card flat bordered class="flex flex-col flex-1 min-h-0">
+    <q-card
+      flat
+      bordered
+      square
+      class="bg-page-elevated flex flex-col flex-1 min-h-0"
+    >
       <q-tabs
         v-model="tabModel"
         dense
-        class="text-grey flex-shrink-0"
+        class="text-text-muted flex-shrink-0"
         active-color="primary"
         indicator-color="primary"
         align="left"
         narrow-indicator
       >
-        <q-tab name="documents" label="Documents" icon="description" />
-        <q-tab name="overview" label="Overview" icon="analytics" />
-        <q-tab name="settings" label="Settings" icon="settings" />
+        <q-tab name="documents" label="Documents" icon="description" no-caps />
+        <q-tab name="settings" label="Settings" icon="settings" no-caps />
+        <q-tab name="playground" label="Playground" icon="terminal" no-caps />
+        <q-tab name="overview" label="Overview" icon="analytics" no-caps />
       </q-tabs>
 
       <q-separator />
@@ -26,12 +32,16 @@
           <slot name="documents-tab" />
         </q-tab-panel>
 
-        <q-tab-panel name="overview" class="p-4">
-          <slot name="overview-tab" />
-        </q-tab-panel>
-
         <q-tab-panel name="settings" class="p-4">
           <slot name="settings-tab" />
+        </q-tab-panel>
+
+        <q-tab-panel name="playground" class="p-0 flex flex-col flex-1 min-h-0">
+          <slot name="playground-tab" />
+        </q-tab-panel>
+
+        <q-tab-panel name="overview" class="p-4">
+          <slot name="overview-tab" />
         </q-tab-panel>
       </q-tab-panels>
     </q-card>

--- a/src/components/SearchExperiencePanel.vue
+++ b/src/components/SearchExperiencePanel.vue
@@ -162,7 +162,7 @@
             </div>
             <div
               v-if="compat.versionString"
-              class="text-caption text-grey-7 mt-3 flex items-center gap-1"
+              class="text-caption text-text-muted mt-3 flex items-center gap-1"
             >
               <q-icon name="info" size="xs" />
               Version-aware mode: {{ compat.versionString }}

--- a/src/components/SearchExperiencePanel.vue
+++ b/src/components/SearchExperiencePanel.vue
@@ -39,9 +39,10 @@
                         class="text-text-muted"
                       >
                         <q-tooltip>
-                          Quick hybrid search mixes. Each preset enables hybrid
-                          and sets semantic ratio (0 = keyword only, 1 =
-                          semantic only).
+                          Quick hybrid search mixes. Each preset enables hybrid,
+                          fills Hybrid Embedder from the index when needed, and
+                          sets semantic ratio (0 = keyword only, 1 = semantic
+                          only).
                         </q-tooltip>
                       </q-icon>
                       <q-btn
@@ -54,7 +55,9 @@
                         :outline="state.activeLlmPreset !== preset.key"
                         :flat="false"
                         color="primary"
-                        :disable="!compat.supportsHybrid"
+                        :disable="
+                          !compat.supportsHybrid || !hasConfiguredEmbedders
+                        "
                         :label="preset.label"
                         @click="$emit('apply-preset', preset.key)"
                       >
@@ -84,6 +87,15 @@
                       <q-icon name="warning" size="xs" />
                       Hybrid presets need Meilisearch newer than 1.11 (current:
                       {{ compat.versionString || "unknown" }}).
+                    </div>
+                    <div
+                      v-else-if="!hasConfiguredEmbedders"
+                      class="text-caption text-warning flex items-center gap-1"
+                    >
+                      <q-icon name="warning" size="xs" />
+                      Hybrid needs an embedder configured on the index
+                      (Settings → AI). Presets will not enable hybrid until one
+                      exists.
                     </div>
                     <div
                       v-else-if="activePresetMeta"
@@ -177,20 +189,32 @@
               <q-toggle
                 v-model="state.enableHybrid"
                 label="Enable Hybrid Search"
-                :disable="!compat.supportsHybrid"
+                :disable="!compat.supportsHybrid || !hasConfiguredEmbedders"
               >
                 <q-tooltip>
                   Mix keyword search with vector/semantic ranking (needs an
                   embedder on the index).
                 </q-tooltip>
               </q-toggle>
+              <q-select
+                v-if="availableEmbedders.length > 0"
+                v-model="state.hybridEmbedder"
+                :options="availableEmbedders"
+                outlined
+                dense
+                clearable
+                label="Hybrid Embedder"
+                hint="Required when hybrid is on (defaults to first index embedder)"
+                :disable="!state.enableHybrid || !compat.supportsHybrid"
+              />
               <q-input
+                v-else
                 v-model="state.hybridEmbedder"
                 outlined
                 dense
                 clearable
-                label="Hybrid Embedder (optional)"
-                hint="Leave blank to use the index default embedder"
+                label="Hybrid Embedder"
+                hint="Required when hybrid is on. Configure embedders under Settings (AI)."
                 :disable="!state.enableHybrid || !compat.supportsHybrid"
               />
               <q-input
@@ -261,6 +285,10 @@ const props = defineProps({
     type: Object,
     default: () => ({}),
   },
+  availableEmbedders: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 defineEmits(["apply-preset", "clear-preset"]);
@@ -272,6 +300,10 @@ const filterDensityOptions = [
   { label: "Compact", value: "compact" },
 ];
 
+const hasConfiguredEmbedders = computed(
+  () => props.availableEmbedders.length > 0,
+);
+
 const activePresetMeta = computed(() => {
   const key = props.state.activeLlmPreset;
   return key ? LLM_DEMO_PRESETS[key] || null : null;
@@ -282,6 +314,7 @@ const hasActivePresetFields = computed(() => {
   return Boolean(
     s.activeLlmPreset ||
       s.enableHybrid ||
+      s.hybridEmbedder ||
       s.hybridSemanticRatio != null ||
       s.showRankingScore ||
       s.showRankingScoreDetails ||

--- a/src/components/SearchExperiencePanel.vue
+++ b/src/components/SearchExperiencePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card flat bordered class="mb-4">
+  <q-card flat bordered square class="bg-page-elevated mb-4">
     <q-card-section class="p-4">
       <div
         class="flex flex-col md:flex-row md:items-stretch gap-3 md:gap-4 mb-3"
@@ -20,34 +20,42 @@
         dense-toggle
         expand-separator
         icon="tune"
-        label="Advanced Search Controls"
-        header-class="text-caption text-grey-7"
+        label="Advanced search / LLM"
+        header-class="text-caption text-text-muted"
       >
         <q-card flat class="mt-2">
           <q-card-section class="px-0 pb-0">
             <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3">
               <div class="md:col-span-3 lg:col-span-4">
-                <q-banner class="bg-indigo-50 text-indigo-9 rounded-md">
+                <q-banner dense class="bg-page text-text border border-border">
                   <div class="flex items-center gap-2 flex-wrap">
-                    <span class="text-caption">LLM Demo Presets:</span>
+                    <span class="text-caption text-text-muted"
+                      >LLM demo presets:</span
+                    >
                     <q-btn
                       flat
                       dense
-                      color="indigo-8"
+                      square
+                      no-caps
+                      color="primary"
                       label="Keyword-heavy"
                       @click="$emit('apply-preset', 'keyword')"
                     />
                     <q-btn
                       flat
                       dense
-                      color="indigo-8"
+                      square
+                      no-caps
+                      color="primary"
                       label="Balanced"
                       @click="$emit('apply-preset', 'balanced')"
                     />
                     <q-btn
                       flat
                       dense
-                      color="indigo-8"
+                      square
+                      no-caps
+                      color="primary"
                       label="Semantic-heavy"
                       @click="$emit('apply-preset', 'semantic')"
                     />

--- a/src/components/SearchExperiencePanel.vue
+++ b/src/components/SearchExperiencePanel.vue
@@ -28,37 +28,73 @@
             <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-3">
               <div class="md:col-span-3 lg:col-span-4">
                 <q-banner dense class="bg-page text-text border border-border">
-                  <div class="flex items-center gap-2 flex-wrap">
-                    <span class="text-caption text-text-muted"
-                      >LLM demo presets:</span
+                  <div class="flex flex-col gap-2">
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <span class="text-caption text-text-muted">
+                        LLM demo presets
+                      </span>
+                      <q-icon
+                        name="help_outline"
+                        size="xs"
+                        class="text-text-muted"
+                      >
+                        <q-tooltip>
+                          Quick hybrid search mixes. Each preset enables hybrid
+                          and sets semantic ratio (0 = keyword only, 1 =
+                          semantic only).
+                        </q-tooltip>
+                      </q-icon>
+                      <q-btn
+                        v-for="preset in presetList"
+                        :key="preset.key"
+                        dense
+                        square
+                        no-caps
+                        :unelevated="state.activeLlmPreset === preset.key"
+                        :outline="state.activeLlmPreset !== preset.key"
+                        :flat="false"
+                        color="primary"
+                        :disable="!compat.supportsHybrid"
+                        :label="preset.label"
+                        @click="$emit('apply-preset', preset.key)"
+                      >
+                        <q-tooltip>{{ preset.tooltip }}</q-tooltip>
+                      </q-btn>
+                      <q-btn
+                        dense
+                        square
+                        flat
+                        no-caps
+                        color="grey-7"
+                        icon="restart_alt"
+                        label="Clear"
+                        :disable="!hasActivePresetFields"
+                        @click="$emit('clear-preset')"
+                      >
+                        <q-tooltip>
+                          Clear preset selection and restore hybrid / ranking
+                          demo defaults
+                        </q-tooltip>
+                      </q-btn>
+                    </div>
+                    <div
+                      v-if="!compat.supportsHybrid"
+                      class="text-caption text-warning flex items-center gap-1"
                     >
-                    <q-btn
-                      flat
-                      dense
-                      square
-                      no-caps
-                      color="primary"
-                      label="Keyword-heavy"
-                      @click="$emit('apply-preset', 'keyword')"
-                    />
-                    <q-btn
-                      flat
-                      dense
-                      square
-                      no-caps
-                      color="primary"
-                      label="Balanced"
-                      @click="$emit('apply-preset', 'balanced')"
-                    />
-                    <q-btn
-                      flat
-                      dense
-                      square
-                      no-caps
-                      color="primary"
-                      label="Semantic-heavy"
-                      @click="$emit('apply-preset', 'semantic')"
-                    />
+                      <q-icon name="warning" size="xs" />
+                      Hybrid presets need Meilisearch newer than 1.11 (current:
+                      {{ compat.versionString || "unknown" }}).
+                    </div>
+                    <div
+                      v-else-if="activePresetMeta"
+                      class="text-caption text-text-muted"
+                    >
+                      Active: {{ activePresetMeta.label }}.
+                      {{ activePresetMeta.caption }}
+                    </div>
+                    <div v-else class="text-caption text-text-muted">
+                      Keyword-heavy 0.2 · Balanced 0.5 · Semantic-heavy 0.8
+                    </div>
                   </div>
                 </q-banner>
               </div>
@@ -74,7 +110,11 @@
                 :max="1"
                 :step="0.01"
                 :disable="!compat.supportsRankingScoreThreshold"
-              />
+              >
+                <q-tooltip>
+                  Drop hits whose ranking score is below this value (0-1).
+                </q-tooltip>
+              </q-input>
               <q-select
                 v-model="state.matchingStrategy"
                 :options="matchingStrategyOptions"
@@ -84,7 +124,12 @@
                 map-options
                 label="Matching Strategy"
                 :disable="!compat.supportsFrequencyMatching"
-              />
+              >
+                <q-tooltip>
+                  How Meilisearch requires query words to match (last / all /
+                  frequency).
+                </q-tooltip>
+              </q-select>
               <q-input
                 v-model="state.distinct"
                 outlined
@@ -92,7 +137,12 @@
                 clearable
                 label="Distinct (query-time)"
                 :disable="!compat.supportsDistinctQuery"
-              />
+              >
+                <q-tooltip>
+                  Return only one hit per distinct attribute value for this
+                  query.
+                </q-tooltip>
+              </q-input>
               <q-toggle
                 v-model="state.showRankingScore"
                 label="Show Ranking Score"
@@ -128,28 +178,41 @@
                 v-model="state.enableHybrid"
                 label="Enable Hybrid Search"
                 :disable="!compat.supportsHybrid"
-              />
+              >
+                <q-tooltip>
+                  Mix keyword search with vector/semantic ranking (needs an
+                  embedder on the index).
+                </q-tooltip>
+              </q-toggle>
               <q-input
                 v-model="state.hybridEmbedder"
                 outlined
                 dense
                 clearable
                 label="Hybrid Embedder (optional)"
+                hint="Leave blank to use the index default embedder"
                 :disable="!state.enableHybrid || !compat.supportsHybrid"
               />
               <q-input
-                v-model.number="state.hybridSemanticRatio"
+                :model-value="hybridRatioDisplay"
                 type="number"
                 outlined
                 dense
                 clearable
                 label="Hybrid Semantic Ratio"
-                hint="0-1 (0 keyword only, 1 semantic only)"
+                hint="0 = keyword only · 1 = semantic only"
                 :min="0"
                 :max="1"
                 :step="0.01"
                 :disable="!state.enableHybrid || !compat.supportsHybrid"
-              />
+                @update:model-value="onHybridRatioUpdate"
+                @clear="onHybridRatioUpdate(null)"
+              >
+                <q-tooltip>
+                  Weight of semantic vs keyword in hybrid mode. Presets set
+                  0.2 / 0.5 / 0.8.
+                </q-tooltip>
+              </q-input>
               <q-select
                 v-model="state.filterDensity"
                 :options="filterDensityOptions"
@@ -175,11 +238,13 @@
 </template>
 
 <script setup>
+import { computed } from "vue";
 import AisSearchInput from "components/aisComponents/AisSearchInput.vue";
 import AisStatsDisplay from "components/aisComponents/AisStatsDisplay.vue";
 import AisSortBySelect from "components/aisComponents/AisSortBySelect.vue";
+import { LLM_DEMO_PRESETS } from "src/meili-core/utils/search-utils";
 
-defineProps({
+const props = defineProps({
   state: {
     type: Object,
     required: true,
@@ -198,10 +263,53 @@ defineProps({
   },
 });
 
-defineEmits(["apply-preset"]);
+defineEmits(["apply-preset", "clear-preset"]);
+
+const presetList = Object.values(LLM_DEMO_PRESETS);
 
 const filterDensityOptions = [
   { label: "Comfortable", value: "comfortable" },
   { label: "Compact", value: "compact" },
 ];
+
+const activePresetMeta = computed(() => {
+  const key = props.state.activeLlmPreset;
+  return key ? LLM_DEMO_PRESETS[key] || null : null;
+});
+
+const hasActivePresetFields = computed(() => {
+  const s = props.state;
+  return Boolean(
+    s.activeLlmPreset ||
+      s.enableHybrid ||
+      s.hybridSemanticRatio != null ||
+      s.showRankingScore ||
+      s.showRankingScoreDetails ||
+      s.showPerformanceDetails,
+  );
+});
+
+const hybridRatioDisplay = computed(() => {
+  const value = props.state.hybridSemanticRatio;
+  if (value === null || value === undefined || value === "") return null;
+  return Number(value);
+});
+
+const onHybridRatioUpdate = (raw) => {
+  if (raw === null || raw === undefined || raw === "") {
+    props.state.hybridSemanticRatio = null;
+    props.state.activeLlmPreset = null;
+    return;
+  }
+  const next = Number(raw);
+  props.state.hybridSemanticRatio = Number.isFinite(next) ? next : null;
+  // Manual edits leave the preset label so it does not look "stuck" selected.
+  const active = props.state.activeLlmPreset;
+  if (active && LLM_DEMO_PRESETS[active]) {
+    const expected = LLM_DEMO_PRESETS[active].hybridSemanticRatio;
+    if (props.state.hybridSemanticRatio !== expected) {
+      props.state.activeLlmPreset = null;
+    }
+  }
+};
 </script>

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -1,129 +1,151 @@
 <template>
-  <PresetSelector @apply-preset="applyPreset" />
+  <div class="settings-form relative pb-20">
+    <PresetSelector @apply-preset="applyPreset" />
 
-  <SettingsBanners
-    :has-unsaved-settings="theSettings.hasUnsavedSettings"
-    :reindexing-fields="reindexingFields"
-  />
+    <SettingsBanners
+      :has-unsaved-settings="theSettings.hasUnsavedSettings"
+      :reindexing-fields="reindexingFields"
+    />
 
-  <!-- Raw JSON Viewer -->
-  <q-expansion-item
-    dense
-    dense-toggle
-    expand-separator
-    icon="code"
-    label="Raw Settings JSON"
-    header-class="text-grey-7"
-    class="q-mb-md"
-  >
-    <q-card flat>
-      <q-card-section>
-        <p class="text-caption text-grey-7 text-center q-mb-md">
-          Real-time view of your complete settings object
-        </p>
-        <pre class="text-caption">{{ iSettingsString }}</pre>
-      </q-card-section>
-    </q-card>
-  </q-expansion-item>
-
-  <div v-if="!fetching">
-    <!-- Tabbed Categories -->
-    <q-tabs
-      v-model="activeTab"
+    <q-expansion-item
       dense
-      active-color="primary"
-      indicator-color="primary"
-      align="justify"
+      dense-toggle
+      expand-separator
+      icon="code"
+      label="Raw Settings JSON"
+      header-class="text-text-muted"
       class="q-mb-md"
     >
-      <q-tab
-        v-for="cat in SETTINGS_CATEGORIES"
-        :key="cat.value"
-        :name="cat.value"
-        :icon="cat.icon"
-        :label="cat.label"
-      />
-    </q-tabs>
+      <q-card flat square bordered class="bg-page">
+        <q-card-section>
+          <p class="text-caption text-text-muted text-center q-mb-md">
+            Real-time view of your complete settings object
+          </p>
+          <pre class="text-caption">{{ iSettingsString }}</pre>
+        </q-card-section>
+      </q-card>
+    </q-expansion-item>
 
-    <q-form @submit="onSubmit" class="q-gutter-md">
-      <q-tab-panels v-model="activeTab" animated>
-        <!-- Search Behavior Tab -->
-        <q-tab-panel name="search">
-          <SearchTab
-            v-model="iSettings"
-            :has-field-changed="hasFieldChanged"
-            @show-searchable-reorder="showSearchableReorder = true"
-          />
-        </q-tab-panel>
-
-        <!-- Relevancy Tab -->
-        <q-tab-panel name="relevancy">
-          <RelevancyTab
-            v-model="iSettings"
-            :has-field-changed="hasFieldChanged"
-            @show-ranking-reorder="showRankingReorder = true"
-          />
-        </q-tab-panel>
-
-        <!-- Performance Tab -->
-        <q-tab-panel name="performance">
-          <PerformanceTab
-            v-model="iSettings"
-            :has-field-changed="hasFieldChanged"
-          />
-        </q-tab-panel>
-        <q-tab-panel name="advanced">
-          <AdvancedTab
-            v-model="iSettings"
-            :has-field-changed="hasFieldChanged"
-          />
-        </q-tab-panel>
-        <q-tab-panel name="ai">
-          <AiTab v-model="iSettings" :has-field-changed="hasFieldChanged" />
-        </q-tab-panel>
-      </q-tab-panels>
-
-      <!-- Submit Section -->
-      <q-separator class="q-my-md" />
-      <div class="flex items-center justify-between">
-        <div class="text-caption text-grey-7">
-          <q-icon name="info" size="xs" class="q-mr-xs" />
-          Changes are not saved until you click Submit
-        </div>
-        <div class="flex gap-2">
-          <q-btn
-            v-if="theSettings.hasUnsavedSettings"
-            flat
-            color="negative"
-            icon="undo"
-            label="Reset to Original"
-            @click="resetToOriginal"
-          >
-            <q-tooltip>Discard all unsaved changes</q-tooltip>
-          </q-btn>
-          <q-btn
-            :loading="iSettingsProcessing.processing"
-            type="submit"
-            color="primary"
-            icon="save"
-            label="Submit Settings"
-          >
-            <template v-slot:loading>
-              <q-spinner-dots />
-              Updating... Task: {{ iSettingsProcessing.taskId }}
-            </template>
-          </q-btn>
-        </div>
+    <div v-if="!fetching">
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <span class="text-caption text-text-muted">Jump to</span>
+        <q-btn
+          v-for="cat in SETTINGS_CATEGORIES"
+          :key="`jump-${cat.value}`"
+          flat
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          :label="cat.label"
+          @click="activeTab = cat.value"
+        />
       </div>
-    </q-form>
 
-    <ReorderDialogs
-      v-model="iSettings"
-      :show-searchable-reorder="showSearchableReorder"
-      :show-ranking-reorder="showRankingReorder"
-      @update:showSearchableReorder="showSearchableReorder = $event"
-      @update:showRankingReorder="showRankingReorder = $event"
-    />
+      <q-tabs
+        v-model="activeTab"
+        dense
+        active-color="primary"
+        indicator-color="primary"
+        align="left"
+        class="q-mb-md"
+      >
+        <q-tab
+          v-for="cat in SETTINGS_CATEGORIES"
+          :key="cat.value"
+          :name="cat.value"
+          :icon="cat.icon"
+          :label="cat.label"
+          no-caps
+        />
+      </q-tabs>
+
+      <q-form @submit="onSubmit" class="q-gutter-md">
+        <q-tab-panels v-model="activeTab" animated>
+          <q-tab-panel name="search">
+            <SearchTab
+              v-model="iSettings"
+              :has-field-changed="hasFieldChanged"
+              @show-searchable-reorder="showSearchableReorder = true"
+            />
+          </q-tab-panel>
+
+          <q-tab-panel name="relevancy">
+            <RelevancyTab
+              v-model="iSettings"
+              :has-field-changed="hasFieldChanged"
+              @show-ranking-reorder="showRankingReorder = true"
+            />
+          </q-tab-panel>
+
+          <q-tab-panel name="performance">
+            <PerformanceTab
+              v-model="iSettings"
+              :has-field-changed="hasFieldChanged"
+            />
+          </q-tab-panel>
+          <q-tab-panel name="advanced">
+            <AdvancedTab
+              v-model="iSettings"
+              :has-field-changed="hasFieldChanged"
+            />
+          </q-tab-panel>
+          <q-tab-panel name="ai">
+            <AiTab v-model="iSettings" :has-field-changed="hasFieldChanged" />
+          </q-tab-panel>
+        </q-tab-panels>
+
+        <div
+          class="sticky-save-bar flex flex-wrap items-center justify-between gap-2 border border-border bg-page-elevated p-3"
+        >
+          <div class="text-caption text-text-muted">
+            <q-icon name="info" size="xs" class="q-mr-xs" />
+            <span v-if="theSettings.hasUnsavedSettings" class="text-warning">
+              Unsaved changes. Submit to apply.
+            </span>
+            <span v-else>Changes are not saved until you click Submit.</span>
+          </div>
+          <div class="flex gap-2">
+            <q-btn
+              v-if="theSettings.hasUnsavedSettings"
+              flat
+              square
+              no-caps
+              color="negative"
+              icon="undo"
+              label="Reset"
+              @click="resetToOriginal"
+            >
+              <q-tooltip>Discard all unsaved changes</q-tooltip>
+            </q-btn>
+            <q-btn
+              :loading="iSettingsProcessing.processing"
+              type="submit"
+              unelevated
+              square
+              no-caps
+              color="primary"
+              icon="save"
+              label="Submit settings"
+            >
+              <template v-slot:loading>
+                <q-spinner-dots />
+                Updating... Task: {{ iSettingsProcessing.taskId }}
+              </template>
+            </q-btn>
+          </div>
+        </div>
+      </q-form>
+
+      <ReorderDialogs
+        v-model="iSettings"
+        :show-searchable-reorder="showSearchableReorder"
+        :show-ranking-reorder="showRankingReorder"
+        @update:showSearchableReorder="showSearchableReorder = $event"
+        @update:showRankingReorder="showRankingReorder = $event"
+      />
+    </div>
   </div>
 </template>
 
@@ -360,3 +382,11 @@ const onSubmit = async () => {
   }
 };
 </script>
+
+<style scoped>
+.sticky-save-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 10;
+}
+</style>

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -129,6 +129,7 @@
               icon="save"
               label="Submit settings"
             >
+              <q-tooltip>Save to Meilisearch (async task)</q-tooltip>
               <template v-slot:loading>
                 <q-spinner-dots />
                 Updating... Task: {{ iSettingsProcessing.taskId }}

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -13,7 +13,7 @@
       expand-separator
       icon="code"
       label="Raw Settings JSON"
-      header-class="text-text-muted"
+      header-class="text-text font-semibold"
       class="q-mb-md"
     >
       <q-card flat square bordered class="bg-page">
@@ -28,7 +28,7 @@
 
     <div v-if="!fetching">
       <div class="flex flex-wrap items-center gap-2 mb-3">
-        <span class="text-caption text-text-muted">Jump to</span>
+        <span class="mm-section-kicker">Jump to</span>
         <q-btn
           v-for="cat in SETTINGS_CATEGORIES"
           :key="`jump-${cat.value}`"
@@ -49,7 +49,7 @@
         active-color="primary"
         indicator-color="primary"
         align="left"
-        class="q-mb-md"
+        class="mm-index-tabs q-mb-md"
       >
         <q-tab
           v-for="cat in SETTINGS_CATEGORIES"

--- a/src/components/SettingsHelp.vue
+++ b/src/components/SettingsHelp.vue
@@ -24,7 +24,7 @@
 
         <q-banner
           v-if="metadata.reindexes"
-          class="bg-warning text-black q-mt-md"
+          class="bg-warning text-page q-mt-md"
           dense
         >
           <template #avatar>

--- a/src/components/SettingsHelp.vue
+++ b/src/components/SettingsHelp.vue
@@ -35,7 +35,7 @@
 
         <q-banner
           v-if="performanceImpact"
-          :class="`bg-${impactColor} text-white q-mt-md`"
+          :class="`bg-${impactColor} text-on-primary q-mt-md`"
           dense
         >
           <template #avatar>

--- a/src/components/aisComponents/AisCurrentRefinements.vue
+++ b/src/components/aisComponents/AisCurrentRefinements.vue
@@ -10,7 +10,6 @@
             removable
             color="primary"
             text-color="white"
-            class="dark:bg-primary dark:text-white"
             @remove="refine(refinement)"
           >
             <span class="font-semibold">{{ item.attribute }}:</span>

--- a/src/components/aisComponents/AisRefinementList.vue
+++ b/src/components/aisComponents/AisRefinementList.vue
@@ -119,14 +119,14 @@ const isCompact = computed(() => props.density !== "comfortable");
 
 const itemClass = computed(() =>
   isCompact.value
-    ? "px-0 py-0 min-h-[22px] hover:bg-gray-100 dark:hover:bg-gray-800 rounded-sm"
-    : "px-2 py-1 min-h-[36px] hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md",
+    ? "px-0 py-0 min-h-[22px] hover:bg-page rounded-sm"
+    : "px-2 py-1 min-h-[36px] hover:bg-page rounded-md",
 );
 
 const labelClass = computed(() =>
   isCompact.value
-    ? "text-[11px] font-medium dark:text-gray-200 break-all leading-tight"
-    : "text-sm font-medium dark:text-gray-200 break-all leading-snug",
+    ? "text-[11px] font-medium text-text break-all leading-tight"
+    : "text-sm font-medium text-text break-all leading-snug",
 );
 
 const badgeClass = computed(() =>
@@ -137,8 +137,8 @@ const badgeClass = computed(() =>
 
 const emptyClass = computed(() =>
   isCompact.value
-    ? "text-[11px] text-gray-500 dark:text-gray-400 px-2 py-1"
-    : "text-sm text-gray-500 dark:text-gray-400 px-3 py-2",
+    ? "text-[11px] text-text-muted px-2 py-1"
+    : "text-sm text-text-muted px-3 py-2",
 );
 
 const visibleItems = (items) => {

--- a/src/components/aisComponents/AisSearchDiagnostics.vue
+++ b/src/components/aisComponents/AisSearchDiagnostics.vue
@@ -1,16 +1,29 @@
 <template>
   <ais-state-results>
-    <template #default="{ results }">
+    <template #default="{ results, state }">
       <q-expansion-item
         dense
         dense-toggle
         expand-separator
         icon="analytics"
         label="Search Diagnostics"
-        header-class="text-caption text-grey-7"
+        header-class="text-caption text-text-muted"
       >
-        <q-card flat bordered class="bg-gray-50 dark:bg-gray-900">
+        <q-card flat bordered square class="bg-page">
           <q-card-section class="text-caption">
+            <div class="flex flex-wrap gap-2 mb-3">
+              <q-btn
+                outline
+                dense
+                square
+                no-caps
+                size="sm"
+                color="primary"
+                icon="terminal"
+                label="Open in Playground"
+                @click="openInPlayground(state)"
+              />
+            </div>
             <div class="mb-2">
               <strong>Request UID:</strong>
               {{ results?.requestUid || "n/a" }}
@@ -63,7 +76,7 @@
 </template>
 
 <script setup>
-defineProps({
+const props = defineProps({
   headerEnabled: {
     type: Boolean,
     default: false,
@@ -84,7 +97,13 @@ defineProps({
     type: Number,
     default: null,
   },
+  indexUid: {
+    type: String,
+    default: "",
+  },
 });
+
+const emit = defineEmits(["open-playground"]);
 
 const getFirstHitValue = (results, key) => {
   const firstHit = results?.hits?.[0];
@@ -97,5 +116,23 @@ const formatValue = (value) => {
     return JSON.stringify(value);
   }
   return String(value);
+};
+
+const openInPlayground = (state) => {
+  const body = {
+    q: state?.query || "",
+    limit: state?.hitsPerPage || 20,
+  };
+  if (props.hybridEnabled) {
+    body.hybrid = {
+      embedder: props.hybridEmbedder || undefined,
+      semanticRatio: props.hybridSemanticRatio ?? 0.5,
+    };
+  }
+  emit("open-playground", {
+    type: "search",
+    indexUid: props.indexUid,
+    body,
+  });
 };
 </script>

--- a/src/components/aisComponents/AisSearchDiagnostics.vue
+++ b/src/components/aisComponents/AisSearchDiagnostics.vue
@@ -123,9 +123,10 @@ const openInPlayground = (state) => {
     q: state?.query || "",
     limit: state?.hitsPerPage || 20,
   };
-  if (props.hybridEnabled) {
+  const embedder = props.hybridEmbedder?.trim();
+  if (props.hybridEnabled && embedder) {
     body.hybrid = {
-      embedder: props.hybridEmbedder || undefined,
+      embedder,
       semanticRatio: props.hybridSemanticRatio ?? 0.5,
     };
   }

--- a/src/components/aisComponents/AisStatsDisplay.vue
+++ b/src/components/aisComponents/AisStatsDisplay.vue
@@ -1,7 +1,7 @@
 <template>
   <ais-stats>
     <template #default="{ nbHits, processingTimeMS }">
-      <div class="text-caption text-grey-7">
+      <div class="text-caption text-text-muted">
         {{ nbHits.toLocaleString() }} results in {{ processingTimeMS }}ms
       </div>
     </template>

--- a/src/components/documents/DocumentHitCard.vue
+++ b/src/components/documents/DocumentHitCard.vue
@@ -43,9 +43,12 @@
               size="sm"
               icon="edit"
               color="primary"
+              aria-label="Edit document"
               :to="editRoute"
               @click.stop
-            />
+            >
+              <q-tooltip>Open full editor</q-tooltip>
+            </q-btn>
             <q-btn
               v-if="showSimilar"
               flat
@@ -54,9 +57,12 @@
               size="sm"
               icon="hub"
               color="secondary"
+              aria-label="Find similar documents"
               :to="similarRoute"
               @click.stop
-            />
+            >
+              <q-tooltip>Similar documents (embeddings)</q-tooltip>
+            </q-btn>
           </div>
 
           <div

--- a/src/components/documents/DocumentHitCard.vue
+++ b/src/components/documents/DocumentHitCard.vue
@@ -2,15 +2,16 @@
   <q-card
     flat
     bordered
-    class="transition-colors hover:border-primary dark:hover:border-primary"
+    square
+    class="bg-page-elevated cursor-pointer transition-colors hover:border-primary"
+    @click="$emit('select', { item, documentId })"
   >
     <q-card-section class="p-3">
       <div class="flex gap-3">
         <div v-if="imageField && getDocumentFieldValue(item, imageField)" class="flex-shrink-0">
           <q-img
             :src="getDocumentFieldValue(item, imageField)"
-            :alt="documentId"
-            class="rounded"
+            :alt="String(documentId)"
             style="width: 64px; height: 64px; object-fit: cover"
             @error="(e) => (e.target.style.display = 'none')"
           />
@@ -19,7 +20,7 @@
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-1 mb-1">
             <span
-              class="font-semibold text-sm truncate dark:text-white flex-1 min-w-0"
+              class="font-semibold text-sm truncate text-text flex-1 min-w-0"
               :title="String(titleLabel)"
             >
               {{ titleLabel }}
@@ -28,28 +29,33 @@
               v-if="canExpand"
               flat
               dense
+              square
               size="sm"
               :icon="expanded ? 'expand_less' : 'expand_more'"
               :label="expanded ? 'Less' : `+${hiddenFieldCount} more`"
               class="text-caption"
-              @click="expanded = !expanded"
+              @click.stop="expanded = !expanded"
             />
             <q-btn
               flat
               dense
+              square
               size="sm"
               icon="edit"
               color="primary"
               :to="editRoute"
+              @click.stop
             />
             <q-btn
               v-if="showSimilar"
               flat
               dense
+              square
               size="sm"
               icon="hub"
               color="secondary"
               :to="similarRoute"
+              @click.stop
             />
           </div>
 
@@ -59,10 +65,10 @@
             :class="gridClass"
           >
             <div v-for="field in visibleFields" :key="field" class="min-w-0">
-              <span class="text-gray-600 dark:text-gray-400">{{ field }}:</span>
+              <span class="text-text-muted">{{ field }}:</span>
               <span
-                class="ml-1 dark:text-gray-200 break-all"
-                :class="{ 'text-gray-400 italic': fieldDisplay(field).missing }"
+                class="ml-1 text-text break-all"
+                :class="{ 'text-text-muted italic': fieldDisplay(field).missing }"
                 :title="fieldDisplay(field).title"
               >
                 {{ fieldDisplay(field).text }}
@@ -139,6 +145,8 @@ const props = defineProps({
     default: false,
   },
 });
+
+defineEmits(["select"]);
 
 const expanded = ref(false);
 

--- a/src/components/documents/DocumentSidePanel.vue
+++ b/src/components/documents/DocumentSidePanel.vue
@@ -13,7 +13,7 @@
         class="flex items-center gap-2 p-3 border-b border-border flex-shrink-0"
       >
         <div class="min-w-0 flex-1">
-          <div class="text-subtitle2 font-semibold truncate">
+          <div class="mm-section-title text-subtitle2 truncate">
             {{ documentId || "Document" }}
           </div>
           <div class="text-caption text-text-muted truncate">

--- a/src/components/documents/DocumentSidePanel.vue
+++ b/src/components/documents/DocumentSidePanel.vue
@@ -99,6 +99,7 @@
           :navigationBar="false"
           :statusBar="true"
           :readOnly="!editable"
+          :dark-theme="darkMode"
           v-model:text="documentText"
         />
         <div v-else class="text-caption text-text-muted p-4">
@@ -112,8 +113,13 @@
 <script setup>
 import { computed, ref, watch } from "vue";
 import { copyToClipboard } from "quasar";
+import { storeToRefs } from "pinia";
 import VueJsoneditor from "vue3-ts-jsoneditor";
+import { useSettingsStore } from "src/meili-core/stores/settings-store";
 import { showSuccess, showError } from "src/utils/notifications";
+
+const theSettings = useSettingsStore();
+const { darkMode } = storeToRefs(theSettings);
 
 const props = defineProps({
   modelValue: {

--- a/src/components/documents/DocumentSidePanel.vue
+++ b/src/components/documents/DocumentSidePanel.vue
@@ -20,7 +20,14 @@
             {{ indexUid }}
           </div>
         </div>
-        <q-btn flat dense square icon="close" @click="close">
+        <q-btn
+          flat
+          dense
+          square
+          icon="close"
+          aria-label="Close document panel"
+          @click="close"
+        >
           <q-tooltip>Close (Esc)</q-tooltip>
         </q-btn>
       </div>
@@ -46,7 +53,9 @@
           :icon="editable ? 'visibility' : 'edit'"
           :label="editable ? 'View only' : 'Edit'"
           @click="editable = !editable"
-        />
+        >
+          <q-tooltip>Toggle JSON edit mode</q-tooltip>
+        </q-btn>
         <q-btn
           flat
           dense

--- a/src/components/documents/DocumentSidePanel.vue
+++ b/src/components/documents/DocumentSidePanel.vue
@@ -1,0 +1,173 @@
+<template>
+  <q-drawer
+    :model-value="modelValue"
+    side="right"
+    overlay
+    bordered
+    :width="drawerWidth"
+    class="bg-page-elevated"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <div class="flex flex-col h-full" @keydown.esc.stop="close">
+      <div
+        class="flex items-center gap-2 p-3 border-b border-border flex-shrink-0"
+      >
+        <div class="min-w-0 flex-1">
+          <div class="text-subtitle2 font-semibold truncate">
+            {{ documentId || "Document" }}
+          </div>
+          <div class="text-caption text-text-muted truncate">
+            {{ indexUid }}
+          </div>
+        </div>
+        <q-btn flat dense square icon="close" @click="close">
+          <q-tooltip>Close (Esc)</q-tooltip>
+        </q-btn>
+      </div>
+
+      <div class="flex flex-wrap gap-1 p-2 border-b border-border flex-shrink-0">
+        <q-btn
+          flat
+          dense
+          square
+          no-caps
+          size="sm"
+          icon="content_copy"
+          label="Copy JSON"
+          color="primary"
+          @click="copyJson"
+        />
+        <q-btn
+          flat
+          dense
+          square
+          no-caps
+          size="sm"
+          :icon="editable ? 'visibility' : 'edit'"
+          :label="editable ? 'View only' : 'Edit'"
+          @click="editable = !editable"
+        />
+        <q-btn
+          flat
+          dense
+          square
+          no-caps
+          size="sm"
+          icon="terminal"
+          label="Playground"
+          color="primary"
+          @click="$emit('open-playground', documentId)"
+        />
+        <q-btn
+          flat
+          dense
+          square
+          no-caps
+          size="sm"
+          icon="open_in_new"
+          label="Full editor"
+          :to="fullEditorRoute"
+        />
+        <q-btn
+          v-if="showSimilar"
+          flat
+          dense
+          square
+          no-caps
+          size="sm"
+          icon="hub"
+          label="Similar"
+          :to="similarRoute"
+        />
+      </div>
+
+      <div class="flex-1 min-h-0 p-2 overflow-hidden">
+        <vue-jsoneditor
+          v-if="documentText !== null"
+          class="h-full min-h-96"
+          :mode="editable ? 'text' : 'view'"
+          :mainMenuBar="false"
+          :navigationBar="false"
+          :statusBar="true"
+          :readOnly="!editable"
+          v-model:text="documentText"
+        />
+        <div v-else class="text-caption text-text-muted p-4">
+          Select a document hit to inspect raw JSON.
+        </div>
+      </div>
+    </div>
+  </q-drawer>
+</template>
+
+<script setup>
+import { computed, ref, watch } from "vue";
+import { copyToClipboard } from "quasar";
+import VueJsoneditor from "vue3-ts-jsoneditor";
+import { showSuccess, showError } from "src/utils/notifications";
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  indexUid: {
+    type: String,
+    required: true,
+  },
+  documentId: {
+    type: [String, Number],
+    default: "",
+  },
+  document: {
+    type: Object,
+    default: null,
+  },
+  showSimilar: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(["update:modelValue", "open-playground"]);
+
+const editable = ref(false);
+const documentText = ref(null);
+const drawerWidth = computed(() =>
+  typeof window !== "undefined" && window.innerWidth < 768 ? 320 : 480,
+);
+
+const fullEditorRoute = computed(
+  () => `/documents/${props.indexUid}/${encodeURIComponent(props.documentId)}`,
+);
+
+const similarRoute = computed(
+  () => `/similar/${props.indexUid}/${encodeURIComponent(props.documentId)}`,
+);
+
+watch(
+  () => props.document,
+  (doc) => {
+    if (!doc) {
+      documentText.value = null;
+      return;
+    }
+    documentText.value = JSON.stringify(doc, null, 2);
+    editable.value = false;
+  },
+  { immediate: true },
+);
+
+const close = () => {
+  emit("update:modelValue", false);
+};
+
+const copyJson = async () => {
+  if (!documentText.value) {
+    showError("Nothing to copy");
+    return;
+  }
+  await copyToClipboard(documentText.value);
+  showSuccess("JSON copied");
+};
+</script>

--- a/src/components/documents/DocumentsDisplayMenu.vue
+++ b/src/components/documents/DocumentsDisplayMenu.vue
@@ -2,6 +2,8 @@
   <q-btn-dropdown
     flat
     dense
+    square
+    no-caps
     color="primary"
     icon="tune"
     label="List display"

--- a/src/components/documents/DocumentsFiltersPanel.vue
+++ b/src/components/documents/DocumentsFiltersPanel.vue
@@ -2,7 +2,7 @@
   <q-card flat bordered square class="h-full flex flex-col min-h-0">
     <q-card-section class="px-2 py-2 flex-shrink-0">
       <div class="flex items-center justify-between gap-1">
-        <span class="text-subtitle2 font-semibold text-text">
+        <span class="mm-section-title text-subtitle2">
           Filters
           <span
             v-if="filterableAttributes.length"

--- a/src/components/documents/DocumentsFiltersPanel.vue
+++ b/src/components/documents/DocumentsFiltersPanel.vue
@@ -2,11 +2,11 @@
   <q-card flat bordered class="h-full flex flex-col min-h-0">
     <q-card-section class="px-2 py-2 flex-shrink-0">
       <div class="flex items-center justify-between gap-1">
-        <span class="text-subtitle2 font-semibold dark:text-white">
+        <span class="text-subtitle2 font-semibold text-text">
           Filters
           <span
             v-if="filterableAttributes.length"
-            class="text-caption text-gray-500 dark:text-gray-400 ml-1"
+            class="text-caption text-text-muted ml-1"
           >
             ({{ visibleAttributeCount }}/{{ filterableAttributes.length }})
           </span>
@@ -18,7 +18,7 @@
             dense
             size="sm"
             icon="close"
-            class="dark:text-gray-300"
+            class="text-text-muted"
             @click="$emit('close')"
           />
         </div>
@@ -110,14 +110,14 @@
 
           <div
             v-if="filterableAttributes.length && !filteredAttributes.length"
-            class="text-caption text-gray-600 dark:text-gray-400 p-3"
+            class="text-caption text-text-muted p-3"
           >
             No attributes match "{{ attributeSearch }}".
           </div>
 
           <div
             v-else-if="!filterableAttributes.length"
-            class="text-caption text-gray-600 dark:text-gray-400 p-3"
+            class="text-caption text-text-muted p-3"
           >
             No filterable attributes on this index. Add them in the Settings tab,
             click Submit Settings, and the facets will appear here.

--- a/src/components/documents/DocumentsFiltersPanel.vue
+++ b/src/components/documents/DocumentsFiltersPanel.vue
@@ -29,7 +29,7 @@
       </div>
 
       <q-input
-        v-model="attributeSearch"
+        :model-value="attributeSearch"
         dense
         outlined
         square
@@ -38,6 +38,7 @@
         label="Search filter attributes"
         placeholder="Attributes or values…"
         class="mt-2"
+        @update:model-value="onAttributeSearchUpdate"
       >
         <template #prepend>
           <q-icon name="search" size="xs" />
@@ -170,6 +171,10 @@ const densityOptions = [
   { label: "Comfy", value: "comfortable" },
 ];
 
+const onAttributeSearchUpdate = (value) => {
+  attributeSearch.value = value ?? "";
+};
+
 const onDensityChange = (value) => {
   if (value === "compact" || value === "comfortable") {
     emit("update:filterDensity", value);
@@ -177,7 +182,7 @@ const onDensityChange = (value) => {
 };
 
 const filteredAttributes = computed(() => {
-  const query = attributeSearch.value.trim().toLowerCase();
+  const query = (attributeSearch.value ?? "").trim().toLowerCase();
   if (!query) return props.filterableAttributes;
   return props.filterableAttributes.filter((attribute) =>
     attribute.toLowerCase().includes(query),
@@ -220,7 +225,7 @@ watch(
 );
 
 watch(filteredAttributes, (attributes) => {
-  if (!attributeSearch.value.trim() || attributes.length !== 1) return;
+  if (!(attributeSearch.value ?? "").trim() || attributes.length !== 1) return;
   const attribute = attributes[0];
   const expanded = new Set(expandedAttributes.value);
   expanded.add(attribute);

--- a/src/components/documents/DocumentsFiltersPanel.vue
+++ b/src/components/documents/DocumentsFiltersPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card flat bordered class="h-full flex flex-col min-h-0">
+  <q-card flat bordered square class="h-full flex flex-col min-h-0">
     <q-card-section class="px-2 py-2 flex-shrink-0">
       <div class="flex items-center justify-between gap-1">
         <span class="text-subtitle2 font-semibold text-text">
@@ -16,11 +16,15 @@
           <q-btn
             flat
             dense
+            square
             size="sm"
             icon="close"
             class="text-text-muted"
+            aria-label="Close filters panel"
             @click="$emit('close')"
-          />
+          >
+            <q-tooltip>Close filters panel</q-tooltip>
+          </q-btn>
         </div>
       </div>
 
@@ -28,9 +32,11 @@
         v-model="attributeSearch"
         dense
         outlined
+        square
         clearable
         debounce="150"
-        placeholder="Search attributes or values…"
+        label="Search filter attributes"
+        placeholder="Attributes or values…"
         class="mt-2"
       >
         <template #prepend>
@@ -69,8 +75,11 @@
           toggle-color="primary"
           class="text-caption"
           :options="densityOptions"
+          aria-label="Filter density"
           @update:model-value="onDensityChange"
-        />
+        >
+          <q-tooltip>Dense or comfortable facet spacing</q-tooltip>
+        </q-btn-toggle>
         <div class="inline-flex items-center gap-0.5">
           <q-toggle
             v-model="hideZeroCounts"

--- a/src/components/documents/DocumentsHitsColumn.vue
+++ b/src/components/documents/DocumentsHitsColumn.vue
@@ -13,14 +13,8 @@
     <ais-hits :escapeHTML="true">
       <template #default="{ items }">
         <div v-if="items.length === 0" class="text-center py-12">
-          <q-icon
-            name="search_off"
-            size="48px"
-            class="text-gray-400 dark:text-gray-600"
-          />
-          <p class="text-subtitle1 text-gray-600 dark:text-gray-400 mt-4">
-            No documents found
-          </p>
+          <q-icon name="search_off" size="48px" class="text-text-muted" />
+          <p class="text-subtitle1 text-text-muted mt-4">No documents found</p>
         </div>
         <DocumentsHitsTable
           v-else-if="displaySettings.listViewMode === 'table'"
@@ -35,6 +29,7 @@
           :nb-hits="searchStats.nbHits"
           :current-page="searchStats.page"
           :hits-per-page="searchStats.hitsPerPage"
+          @select="(payload) => $emit('select', payload)"
         />
         <div v-else class="flex flex-col gap-2 overflow-y-auto flex-1 min-h-0">
           <DocumentHitCard
@@ -53,6 +48,7 @@
             :edit-route="routes(item, index).edit"
             :similar-route="routes(item, index).similar"
             :show-similar="showSimilar"
+            @select="(payload) => $emit('select', payload)"
           />
         </div>
       </template>
@@ -104,6 +100,8 @@ const props = defineProps({
     default: false,
   },
 });
+
+defineEmits(["select"]);
 
 const searchStats = ref({
   nbHits: 0,

--- a/src/components/documents/DocumentsHitsTable.vue
+++ b/src/components/documents/DocumentsHitsTable.vue
@@ -32,9 +32,12 @@
                 size="sm"
                 icon="edit"
                 color="primary"
+                aria-label="Edit document"
                 :to="bodyProps.row.__editRoute"
                 @click.stop
-              />
+              >
+                <q-tooltip>Open full editor</q-tooltip>
+              </q-btn>
             </template>
             <template v-else>
               <span

--- a/src/components/documents/DocumentsHitsTable.vue
+++ b/src/components/documents/DocumentsHitsTable.vue
@@ -13,37 +13,47 @@
       class="documents-hits-table flex-1 min-h-0"
       :style="{ maxHeight: tableMaxHeight }"
     >
-      <template #body-cell-actions="cell">
-        <q-td :props="cell" auto-width>
-          <q-btn
-            flat
-            dense
-            round
-            size="sm"
-            icon="edit"
-            color="primary"
-            :to="cell.row.__editRoute"
-          />
-        </q-td>
-      </template>
-      <template
-        v-for="field in tableFields"
-        :key="field"
-        #[`body-cell-${field}`]="cell"
-      >
-        <q-td :props="cell">
-          <span
-            class="text-xs break-all"
-            :class="{ 'text-gray-400 italic': cell.row[`__missing__${field}`] }"
-            :title="cell.row[`__title__${field}`]"
+      <template #body="bodyProps">
+        <q-tr
+          :props="bodyProps"
+          class="cursor-pointer"
+          @click="$emit('select', { item: bodyProps.row.__item, documentId: bodyProps.row.__rowKey })"
+        >
+          <q-td
+            v-for="col in bodyProps.cols"
+            :key="col.name"
+            :props="bodyProps"
           >
-            {{ cell.row[field] }}
-          </span>
-        </q-td>
+            <template v-if="col.name === 'actions'">
+              <q-btn
+                flat
+                dense
+                square
+                size="sm"
+                icon="edit"
+                color="primary"
+                :to="bodyProps.row.__editRoute"
+                @click.stop
+              />
+            </template>
+            <template v-else>
+              <span
+                class="text-xs break-all"
+                :class="{
+                  'text-text-muted italic':
+                    bodyProps.row[`__missing__${col.name}`],
+                }"
+                :title="bodyProps.row[`__title__${col.name}`]"
+              >
+                {{ bodyProps.row[col.name] }}
+              </span>
+            </template>
+          </q-td>
+        </q-tr>
       </template>
     </q-table>
 
-    <div class="text-caption text-gray-500 dark:text-gray-400 py-2 px-1 text-center flex-shrink-0">
+    <div class="text-caption text-text-muted py-2 px-1 text-center flex-shrink-0">
       {{ pageSummary }}
     </div>
   </div>
@@ -109,6 +119,8 @@ const props = defineProps({
   },
 });
 
+defineEmits(["select"]);
+
 const tableMaxHeight = "calc(100vh - 280px)";
 
 const tableFields = computed(() =>
@@ -146,6 +158,7 @@ const rows = computed(() =>
     const row = {
       __rowKey: id,
       __editRoute: routes.edit,
+      __item: item,
     };
     for (const field of tableFields.value) {
       const display = formatDocumentFieldDisplay(item, field, {
@@ -169,6 +182,6 @@ const pageSummary = computed(() => {
   const end = Math.min(start + props.items.length - 1, total);
   if (total <= 0) return "No matching documents";
   if (props.items.length === 0) return `${total.toLocaleString()} matching documents`;
-  return `Showing ${start.toLocaleString()}–${end.toLocaleString()} of ${total.toLocaleString()} matching documents (search page ${page})`;
+  return `Showing ${start.toLocaleString()}-${end.toLocaleString()} of ${total.toLocaleString()} matching documents (search page ${page})`;
 });
 </script>

--- a/src/components/documents/FilterAttributesList.vue
+++ b/src/components/documents/FilterAttributesList.vue
@@ -100,8 +100,8 @@ const headerClass = computed(() =>
 
 const headerLabelClass = computed(() =>
   isCompact.value
-    ? "text-xs font-medium break-all dark:text-gray-200 leading-tight"
-    : "text-sm font-semibold break-all dark:text-gray-200 leading-snug",
+    ? "text-xs font-medium break-all text-text leading-tight"
+    : "text-sm font-semibold break-all text-text leading-snug",
 );
 
 const activeCount = (attribute) =>

--- a/src/components/documents/ListFieldsOrderDialog.vue
+++ b/src/components/documents/ListFieldsOrderDialog.vue
@@ -9,7 +9,7 @@
       <q-card-section class="pt-2">
         <div
           v-if="orderedFields.length === 0"
-          class="text-caption text-grey-7"
+          class="text-caption text-text-muted"
         >
           No fields selected. Add fields from the List fields picker first.
         </div>

--- a/src/components/dynamicRules/DynamicRuleEditorDialog.vue
+++ b/src/components/dynamicRules/DynamicRuleEditorDialog.vue
@@ -17,7 +17,7 @@
       </q-card-section>
 
       <q-card-section class="flex flex-col gap-4">
-        <q-banner rounded class="bg-grey-2 text-grey-9">
+        <q-banner rounded class="bg-page-elevated text-text border border-border">
           Conditions are combined with <strong>AND</strong>. Lower
           <strong>priority</strong> wins when rules conflict. If different
           documents pin to the same position, ascending priority breaks ties.
@@ -62,7 +62,7 @@
           <div
             v-for="(row, idx) in conditionRows"
             :key="`c-${idx}`"
-            class="flex flex-wrap gap-2 items-end mb-2 p-3 rounded border border-gray-200 dark:border-gray-700"
+            class="flex flex-wrap gap-2 items-end mb-2 p-3 border border-border"
           >
             <q-select
               v-model="row.scope"
@@ -134,7 +134,7 @@
         <q-banner
           v-if="pinPositionDuplicateHint"
           rounded
-          class="bg-amber-2 text-amber-10"
+          class="bg-page-elevated text-text border border-border"
         >
           {{ pinPositionDuplicateHint }}
         </q-banner>
@@ -144,7 +144,7 @@
           <div
             v-for="(row, idx) in pinRows"
             :key="`p-${idx}`"
-            class="flex flex-wrap gap-2 items-end mb-2 p-3 rounded border border-gray-200 dark:border-gray-700"
+            class="flex flex-wrap gap-2 items-end mb-2 p-3 border border-border"
           >
             <q-select
               v-model="row.indexUid"

--- a/src/components/dynamicRules/DynamicRuleTestDialog.vue
+++ b/src/components/dynamicRules/DynamicRuleTestDialog.vue
@@ -14,7 +14,7 @@
       </q-card-section>
 
       <q-card-section class="flex flex-col gap-4">
-        <q-banner v-if="!defaultIndexUid" rounded class="bg-amber-2 text-amber-10">
+        <q-banner v-if="!defaultIndexUid" rounded class="bg-page-elevated text-text border border-border">
           This rule has no pin actions with an index; choose an index manually below.
         </q-banner>
 
@@ -59,7 +59,7 @@
           />
         </div>
 
-        <div v-if="searchMeta !== null" class="text-caption text-grey-7">
+        <div v-if="searchMeta !== null" class="text-caption text-text-muted">
           Processing time ms: {{ searchMeta?.processingTimeMs ?? "—" }} · hits:
           {{ hits.length }}
         </div>
@@ -73,11 +73,11 @@
           :columns="columns"
           row-key="position"
         />
-        <div v-else-if="ranOnce && !searching" class="text-grey-7 text-caption">
+        <div v-else-if="ranOnce && !searching" class="text-text-muted text-caption">
           No hits returned.
         </div>
 
-        <q-banner v-if="expectations.length" rounded class="bg-grey-2 text-grey-9">
+        <q-banner v-if="expectations.length" rounded class="bg-page-elevated text-text border border-border">
           <div class="text-weight-medium mb-1">Expected pins (from rule)</div>
           <ul class="q-pl-md q-my-none">
             <li v-for="(ex, i) in expectations" :key="i">

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -25,7 +25,9 @@
           "
           :label="tpl.label"
           @click="applyTemplate(tpl)"
-        />
+        >
+          <q-tooltip>{{ templateHint(tpl) }}</q-tooltip>
+        </q-btn>
       </div>
       <q-space />
       <q-toggle
@@ -34,7 +36,9 @@
         dense
         color="warning"
         label="I confirm write / delete"
-      />
+      >
+        <q-tooltip>Required before send on write or delete requests</q-tooltip>
+      </q-toggle>
       <q-btn
         unelevated
         square
@@ -46,7 +50,7 @@
         :disable="needsWriteConfirm && !writeConfirmed"
         @click="sendRequest"
       >
-        <q-tooltip>Ctrl/Cmd+Enter</q-tooltip>
+        <q-tooltip>Send request (Ctrl/Cmd+Enter)</q-tooltip>
       </q-btn>
     </div>
 
@@ -65,7 +69,9 @@
           class="border-border"
           label="Copy curl"
           @click="copyExport('curl', true)"
-        />
+        >
+          <q-tooltip>Copy curl with API key redacted</q-tooltip>
+        </q-btn>
         <q-btn
           outline
           dense
@@ -76,7 +82,9 @@
           class="border-border"
           label="curl + key"
           @click="copyExport('curl', false)"
-        />
+        >
+          <q-tooltip>Includes API key. Share carefully.</q-tooltip>
+        </q-btn>
         <q-btn
           outline
           dense
@@ -87,7 +95,9 @@
           class="border-border"
           label="Copy HTTP"
           @click="copyExport('http', true)"
-        />
+        >
+          <q-tooltip>Copy HTTP request with API key redacted</q-tooltip>
+        </q-btn>
         <q-btn
           outline
           dense
@@ -98,7 +108,9 @@
           class="border-border"
           label="Copy n8n JSON"
           @click="copyExport('n8n', true)"
-        />
+        >
+          <q-tooltip>Copy n8n node JSON with API key redacted</q-tooltip>
+        </q-btn>
         <q-btn
           outline
           dense
@@ -109,7 +121,9 @@
           class="border-border"
           label="n8n + key"
           @click="copyExport('n8n', false)"
-        />
+        >
+          <q-tooltip>Includes API key. Share carefully.</q-tooltip>
+        </q-btn>
       </div>
     </div>
 
@@ -172,6 +186,7 @@
               dense
               square
               label="q"
+              hint="Search query"
               @update:model-value="syncKnobsToBody"
             />
             <q-input
@@ -180,6 +195,7 @@
               dense
               square
               label="filter"
+              hint="Filter expression"
               @update:model-value="syncKnobsToBody"
             />
             <q-input
@@ -297,6 +313,18 @@ const props = defineProps({
 const theSettings = useSettingsStore();
 const templates = PLAYGROUND_TEMPLATES;
 const methodOptions = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+const TEMPLATE_HINTS = {
+  search: "POST search this index",
+  "get-document": "GET one document by id",
+  "get-settings": "GET index settings",
+  "get-stats": "GET index stats",
+  "add-documents": "POST documents (write)",
+  "delete-document": "DELETE one document by id",
+};
+
+const templateHint = (tpl) =>
+  TEMPLATE_HINTS[tpl.id] || `${tpl.method} ${tpl.label}`;
 
 const method = ref("POST");
 const path = ref("");

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -6,7 +6,7 @@
     <div
       class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated p-2"
     >
-      <span class="text-caption text-text-muted mr-1">Presets</span>
+      <span class="mm-section-kicker mr-1">Presets</span>
       <div class="flex flex-wrap items-stretch gap-1">
         <q-btn
           v-for="tpl in templates"
@@ -57,7 +57,7 @@
     <div
       class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated px-2 py-1.5"
     >
-      <span class="text-caption text-text-muted">Export for n8n / curl</span>
+      <span class="mm-section-kicker">Export for n8n / curl</span>
       <div class="flex flex-wrap items-stretch gap-1">
         <q-btn
           outline
@@ -136,7 +136,7 @@
     >
       <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
         <q-card-section class="pb-2">
-          <div class="text-subtitle2 font-semibold mb-1">Request</div>
+          <div class="mm-section-title text-subtitle2 mb-1">Request</div>
           <div class="text-caption text-text-muted mb-3">
             Build method and path, then Send.
           </div>
@@ -167,7 +167,7 @@
         <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
           <div class="flex items-center justify-between gap-2 mb-2">
             <div>
-              <div class="text-subtitle2 font-semibold">Body</div>
+              <div class="mm-section-title text-subtitle2">Body</div>
               <div class="text-caption text-text-muted">Request body (JSON)</div>
             </div>
             <q-btn
@@ -186,9 +186,7 @@
             </q-btn>
           </div>
           <div v-if="isSearchRequest" class="mb-3">
-            <div class="text-caption text-text-muted font-medium mb-2">
-              Search options
-            </div>
+            <div class="mm-section-kicker mb-2">Search options</div>
             <div class="grid grid-cols-2 gap-2">
               <q-input
                 v-model="searchKnobs.q"
@@ -267,7 +265,7 @@
           <div class="flex items-center justify-between gap-2 mb-2">
             <div class="flex items-center gap-2 min-w-0">
               <div>
-                <div class="text-subtitle2 font-semibold">Response</div>
+                <div class="mm-section-title text-subtitle2">Response</div>
                 <div
                   v-if="responseMeta"
                   class="text-caption text-text-muted truncate"

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -1,0 +1,455 @@
+<template>
+  <div
+    class="playground-panel flex flex-col flex-1 min-h-0 p-3 gap-3"
+    @keydown="onKeydown"
+  >
+    <div
+      class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page p-2"
+    >
+      <q-btn
+        v-for="tpl in templates"
+        :key="tpl.id"
+        flat
+        dense
+        square
+        no-caps
+        size="sm"
+        color="primary"
+        :label="tpl.label"
+        @click="applyTemplate(tpl)"
+      />
+      <q-space />
+      <q-toggle
+        v-if="needsWriteConfirm"
+        v-model="writeConfirmed"
+        dense
+        color="warning"
+        label="I confirm write / delete"
+      />
+      <q-btn
+        unelevated
+        square
+        no-caps
+        color="primary"
+        icon="send"
+        label="Send"
+        :loading="sending"
+        :disable="needsWriteConfirm && !writeConfirmed"
+        @click="sendRequest"
+      >
+        <q-tooltip>Ctrl/Cmd+Enter</q-tooltip>
+      </q-btn>
+    </div>
+
+    <div
+      class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated p-2"
+    >
+      <span class="text-caption text-text-muted">Export</span>
+      <q-btn
+        outline
+        dense
+        square
+        no-caps
+        size="sm"
+        color="primary"
+        label="Copy curl"
+        @click="copyExport('curl', true)"
+      />
+      <q-btn
+        flat
+        dense
+        square
+        no-caps
+        size="sm"
+        color="primary"
+        label="curl + key"
+        @click="copyExport('curl', false)"
+      />
+      <q-btn
+        outline
+        dense
+        square
+        no-caps
+        size="sm"
+        color="primary"
+        label="Copy HTTP"
+        @click="copyExport('http', true)"
+      />
+      <q-btn
+        outline
+        dense
+        square
+        no-caps
+        size="sm"
+        color="primary"
+        label="Copy n8n JSON"
+        @click="copyExport('n8n', true)"
+      />
+      <q-btn
+        flat
+        dense
+        square
+        no-caps
+        size="sm"
+        color="primary"
+        label="n8n + key"
+        @click="copyExport('n8n', false)"
+      />
+    </div>
+
+    <div
+      class="grid grid-cols-1 xl:grid-cols-3 gap-3 flex-1 min-h-0 overflow-auto"
+    >
+      <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
+        <q-card-section class="pb-2">
+          <div class="text-subtitle2 font-semibold mb-3">Request</div>
+          <q-select
+            v-model="method"
+            :options="methodOptions"
+            outlined
+            dense
+            square
+            label="Method"
+            class="mb-3"
+            @update:model-value="persist"
+          />
+          <q-input
+            v-model="path"
+            outlined
+            dense
+            square
+            label="Path"
+            hint="Relative to instance host"
+            class="mb-2"
+            @update:model-value="persist"
+          />
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
+        <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
+          <div class="text-subtitle2 font-semibold mb-2">Body / knobs</div>
+          <div
+            v-if="method === 'POST' && path.includes('/search')"
+            class="grid grid-cols-2 gap-2 mb-3"
+          >
+            <q-input
+              v-model="searchKnobs.q"
+              outlined
+              dense
+              square
+              label="q"
+              @update:model-value="syncKnobsToBody"
+            />
+            <q-input
+              v-model="searchKnobs.filter"
+              outlined
+              dense
+              square
+              label="filter"
+              @update:model-value="syncKnobsToBody"
+            />
+            <q-input
+              v-model.number="searchKnobs.limit"
+              type="number"
+              outlined
+              dense
+              square
+              label="limit"
+              @update:model-value="syncKnobsToBody"
+            />
+            <q-input
+              v-model.number="searchKnobs.offset"
+              type="number"
+              outlined
+              dense
+              square
+              label="offset"
+              @update:model-value="syncKnobsToBody"
+            />
+            <q-input
+              v-model="searchKnobs.sort"
+              outlined
+              dense
+              square
+              label="sort (comma)"
+              class="col-span-2"
+              @update:model-value="syncKnobsToBody"
+            />
+            <q-input
+              v-model="searchKnobs.attributesToRetrieve"
+              outlined
+              dense
+              square
+              label="attributesToRetrieve (comma)"
+              class="col-span-2"
+              @update:model-value="syncKnobsToBody"
+            />
+          </div>
+          <q-input
+            v-model="body"
+            type="textarea"
+            outlined
+            dense
+            square
+            autogrow
+            class="font-mono text-caption flex-1"
+            label="JSON body"
+            :disable="!needsBody"
+            @update:model-value="persist"
+          />
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
+        <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
+          <div class="flex items-center justify-between mb-2">
+            <div class="text-subtitle2 font-semibold">Response</div>
+            <div v-if="responseMeta" class="text-caption text-text-muted">
+              {{ responseMeta.status }} · {{ responseMeta.durationMs }}ms
+            </div>
+          </div>
+          <pre
+            class="text-caption whitespace-pre-wrap break-all overflow-auto flex-1 min-h-48 bg-page p-3 border border-border"
+            >{{ responseText || "Send a request to see the response." }}</pre
+          >
+        </q-card-section>
+      </q-card>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, watch } from "vue";
+import { copyToClipboard } from "quasar";
+import { useSettingsStore } from "src/meili-core/stores/settings-store";
+import {
+  PLAYGROUND_TEMPLATES,
+  buildExportRequest,
+  executePlaygroundRequest,
+  isDestructiveMethod,
+  serializeCurl,
+  serializeHttp,
+  serializeN8nJson,
+} from "src/meili-core/utils/playground-request";
+import { showError, showSuccess } from "src/utils/notifications";
+
+const props = defineProps({
+  indexUid: {
+    type: String,
+    required: true,
+  },
+});
+
+const theSettings = useSettingsStore();
+const templates = PLAYGROUND_TEMPLATES;
+const methodOptions = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+const method = ref("POST");
+const path = ref("");
+const body = ref("");
+const sending = ref(false);
+const writeConfirmed = ref(false);
+const responseText = ref("");
+const responseMeta = ref(null);
+
+const searchKnobs = reactive({
+  q: "",
+  filter: "",
+  limit: 20,
+  offset: 0,
+  sort: "",
+  attributesToRetrieve: "",
+});
+
+const needsBody = computed(() =>
+  ["POST", "PUT", "PATCH"].includes(method.value),
+);
+
+const needsWriteConfirm = computed(() =>
+  isDestructiveMethod(method.value, path.value),
+);
+
+const persist = () => {
+  theSettings.setIndexPlaygroundState(props.indexUid, {
+    method: method.value,
+    path: path.value,
+    body: body.value,
+  });
+};
+
+const applyTemplate = (tpl) => {
+  method.value = tpl.method;
+  path.value = tpl.path(props.indexUid);
+  body.value = tpl.body || "";
+  writeConfirmed.value = false;
+  if (tpl.id === "search") {
+    syncBodyToKnobs();
+  }
+  persist();
+};
+
+const syncBodyToKnobs = () => {
+  try {
+    const parsed = JSON.parse(body.value || "{}");
+    searchKnobs.q = parsed.q ?? "";
+    searchKnobs.filter = parsed.filter ?? "";
+    searchKnobs.limit = parsed.limit ?? 20;
+    searchKnobs.offset = parsed.offset ?? 0;
+    searchKnobs.sort = Array.isArray(parsed.sort)
+      ? parsed.sort.join(",")
+      : parsed.sort || "";
+    searchKnobs.attributesToRetrieve = Array.isArray(
+      parsed.attributesToRetrieve,
+    )
+      ? parsed.attributesToRetrieve.join(",")
+      : "";
+  } catch {
+    // Keep knobs as-is when body is invalid JSON.
+  }
+};
+
+const syncKnobsToBody = () => {
+  let parsed = {};
+  try {
+    parsed = JSON.parse(body.value || "{}");
+  } catch {
+    parsed = {};
+  }
+  parsed.q = searchKnobs.q;
+  if (searchKnobs.filter) parsed.filter = searchKnobs.filter;
+  else delete parsed.filter;
+  parsed.limit = Number(searchKnobs.limit) || 20;
+  parsed.offset = Number(searchKnobs.offset) || 0;
+  if (searchKnobs.sort) {
+    parsed.sort = searchKnobs.sort
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } else {
+    delete parsed.sort;
+  }
+  if (searchKnobs.attributesToRetrieve) {
+    parsed.attributesToRetrieve = searchKnobs.attributesToRetrieve
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } else {
+    delete parsed.attributesToRetrieve;
+  }
+  body.value = JSON.stringify(parsed, null, 2);
+  persist();
+};
+
+const sendRequest = async () => {
+  if (needsWriteConfirm.value && !writeConfirmed.value) {
+    showError("Confirm write / delete before sending.");
+    return;
+  }
+  sending.value = true;
+  try {
+    const result = await executePlaygroundRequest({
+      host: theSettings.indexUrl,
+      apiKey: theSettings.indexKey,
+      method: method.value,
+      path: path.value,
+      body: body.value,
+    });
+    responseMeta.value = {
+      status: result.status,
+      durationMs: result.durationMs,
+    };
+    responseText.value =
+      typeof result.data === "string"
+        ? result.data
+        : JSON.stringify(result.data, null, 2);
+    if (!result.ok) {
+      showError(`Request failed (${result.status})`);
+    }
+  } catch (error) {
+    showError(`Request error: ${error.message}`);
+    responseText.value = error.message;
+  } finally {
+    sending.value = false;
+  }
+};
+
+const copyExport = async (kind, redact) => {
+  const req = buildExportRequest({
+    host: theSettings.indexUrl,
+    apiKey: theSettings.indexKey,
+    method: method.value,
+    path: path.value,
+    body: body.value,
+    redact,
+  });
+  let text = "";
+  if (kind === "curl") text = serializeCurl(req);
+  else if (kind === "http") text = serializeHttp(req);
+  else text = serializeN8nJson(req);
+  await copyToClipboard(text);
+  showSuccess(
+    redact ? "Copied (redacted Bearer)" : "Copied (includes API key)",
+  );
+};
+
+const onKeydown = (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+    e.preventDefault();
+    sendRequest();
+  }
+};
+
+const applySeed = (seed) => {
+  if (!seed || seed.indexUid !== props.indexUid) return;
+  if (seed.type === "document" && seed.documentId != null) {
+    method.value = "GET";
+    path.value = `/indexes/${props.indexUid}/documents/${encodeURIComponent(seed.documentId)}`;
+    body.value = "";
+  } else if (seed.type === "search") {
+    method.value = "POST";
+    path.value = `/indexes/${props.indexUid}/search`;
+    body.value =
+      typeof seed.body === "string"
+        ? seed.body
+        : JSON.stringify(seed.body || { q: "", limit: 20 }, null, 2);
+    syncBodyToKnobs();
+  }
+  persist();
+};
+
+onMounted(() => {
+  const saved = theSettings.getIndexPlaygroundState(props.indexUid);
+  method.value = saved.method || "POST";
+  path.value =
+    saved.path || `/indexes/${props.indexUid}/search`;
+  body.value = saved.body || '{\n  "q": "",\n  "limit": 20\n}';
+  syncBodyToKnobs();
+
+  const seed = theSettings.consumePlaygroundSeed();
+  if (seed) applySeed(seed);
+});
+
+watch(
+  () => props.indexUid,
+  (uid) => {
+    const saved = theSettings.getIndexPlaygroundState(uid);
+    method.value = saved.method || "POST";
+    path.value = saved.path || `/indexes/${uid}/search`;
+    body.value = saved.body || '{\n  "q": "",\n  "limit": 20\n}';
+    syncBodyToKnobs();
+    writeConfirmed.value = false;
+    responseText.value = "";
+    responseMeta.value = null;
+  },
+);
+
+watch(
+  () => theSettings.playgroundSeed,
+  (seed) => {
+    if (!seed) return;
+    const consumed = theSettings.consumePlaygroundSeed();
+    if (consumed) applySeed(consumed);
+  },
+);
+</script>

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -4,20 +4,29 @@
     @keydown="onKeydown"
   >
     <div
-      class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page p-2"
+      class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated p-2"
     >
-      <q-btn
-        v-for="tpl in templates"
-        :key="tpl.id"
-        flat
-        dense
-        square
-        no-caps
-        size="sm"
-        color="primary"
-        :label="tpl.label"
-        @click="applyTemplate(tpl)"
-      />
+      <span class="text-caption text-text-muted mr-1">Presets</span>
+      <div class="flex flex-wrap items-stretch gap-1">
+        <q-btn
+          v-for="tpl in templates"
+          :key="tpl.id"
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          :unelevated="activeTemplateId === tpl.id"
+          :outline="activeTemplateId !== tpl.id"
+          :class="
+            activeTemplateId === tpl.id
+              ? 'bg-primary text-on-primary'
+              : 'border-border'
+          "
+          :label="tpl.label"
+          @click="applyTemplate(tpl)"
+        />
+      </div>
       <q-space />
       <q-toggle
         v-if="needsWriteConfirm"
@@ -45,56 +54,63 @@
       class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated p-2"
     >
       <span class="text-caption text-text-muted">Export</span>
-      <q-btn
-        outline
-        dense
-        square
-        no-caps
-        size="sm"
-        color="primary"
-        label="Copy curl"
-        @click="copyExport('curl', true)"
-      />
-      <q-btn
-        flat
-        dense
-        square
-        no-caps
-        size="sm"
-        color="primary"
-        label="curl + key"
-        @click="copyExport('curl', false)"
-      />
-      <q-btn
-        outline
-        dense
-        square
-        no-caps
-        size="sm"
-        color="primary"
-        label="Copy HTTP"
-        @click="copyExport('http', true)"
-      />
-      <q-btn
-        outline
-        dense
-        square
-        no-caps
-        size="sm"
-        color="primary"
-        label="Copy n8n JSON"
-        @click="copyExport('n8n', true)"
-      />
-      <q-btn
-        flat
-        dense
-        square
-        no-caps
-        size="sm"
-        color="primary"
-        label="n8n + key"
-        @click="copyExport('n8n', false)"
-      />
+      <div class="flex flex-wrap items-stretch gap-1">
+        <q-btn
+          outline
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          class="border-border"
+          label="Copy curl"
+          @click="copyExport('curl', true)"
+        />
+        <q-btn
+          outline
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          class="border-border"
+          label="curl + key"
+          @click="copyExport('curl', false)"
+        />
+        <q-btn
+          outline
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          class="border-border"
+          label="Copy HTTP"
+          @click="copyExport('http', true)"
+        />
+        <q-btn
+          outline
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          class="border-border"
+          label="Copy n8n JSON"
+          @click="copyExport('n8n', true)"
+        />
+        <q-btn
+          outline
+          dense
+          square
+          no-caps
+          size="sm"
+          color="primary"
+          class="border-border"
+          label="n8n + key"
+          @click="copyExport('n8n', false)"
+        />
+      </div>
     </div>
 
     <div
@@ -111,7 +127,7 @@
             square
             label="Method"
             class="mb-3"
-            @update:model-value="persist"
+            @update:model-value="onRequestEdited"
           />
           <q-input
             v-model="path"
@@ -121,14 +137,31 @@
             label="Path"
             hint="Relative to instance host"
             class="mb-2"
-            @update:model-value="persist"
+            @update:model-value="onRequestEdited"
           />
         </q-card-section>
       </q-card>
 
       <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
         <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
-          <div class="text-subtitle2 font-semibold mb-2">Body / knobs</div>
+          <div class="flex items-center justify-between gap-2 mb-2">
+            <div class="text-subtitle2 font-semibold">Body / knobs</div>
+            <q-btn
+              outline
+              dense
+              square
+              no-caps
+              size="sm"
+              color="primary"
+              class="border-border"
+              icon="content_copy"
+              label="Copy"
+              :disable="!needsBody || !body.trim()"
+              @click="copyBody"
+            >
+              <q-tooltip>Copy JSON body</q-tooltip>
+            </q-btn>
+          </div>
           <div
             v-if="method === 'POST' && path.includes('/search')"
             class="grid grid-cols-2 gap-2 mb-3"
@@ -203,11 +236,31 @@
 
       <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
         <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
-          <div class="flex items-center justify-between mb-2">
-            <div class="text-subtitle2 font-semibold">Response</div>
-            <div v-if="responseMeta" class="text-caption text-text-muted">
-              {{ responseMeta.status }} · {{ responseMeta.durationMs }}ms
+          <div class="flex items-center justify-between gap-2 mb-2">
+            <div class="flex items-center gap-2 min-w-0">
+              <div class="text-subtitle2 font-semibold">Response</div>
+              <div
+                v-if="responseMeta"
+                class="text-caption text-text-muted truncate"
+              >
+                {{ responseMeta.status }} · {{ responseMeta.durationMs }}ms
+              </div>
             </div>
+            <q-btn
+              outline
+              dense
+              square
+              no-caps
+              size="sm"
+              color="primary"
+              class="border-border"
+              icon="content_copy"
+              label="Copy"
+              :disable="!hasCopyableResponse"
+              @click="copyResponse"
+            >
+              <q-tooltip>Copy response</q-tooltip>
+            </q-btn>
           </div>
           <pre
             class="text-caption whitespace-pre-wrap break-all overflow-auto flex-1 min-h-48 bg-page p-3 border border-border"
@@ -221,7 +274,6 @@
 
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from "vue";
-import { copyToClipboard } from "quasar";
 import { useSettingsStore } from "src/meili-core/stores/settings-store";
 import {
   PLAYGROUND_TEMPLATES,
@@ -232,7 +284,8 @@ import {
   serializeHttp,
   serializeN8nJson,
 } from "src/meili-core/utils/playground-request";
-import { showError, showSuccess } from "src/utils/notifications";
+import { copyText } from "src/utils/clipboard";
+import { showError } from "src/utils/notifications";
 
 const props = defineProps({
   indexUid: {
@@ -252,6 +305,7 @@ const sending = ref(false);
 const writeConfirmed = ref(false);
 const responseText = ref("");
 const responseMeta = ref(null);
+const activeTemplateId = ref(null);
 
 const searchKnobs = reactive({
   q: "",
@@ -270,6 +324,10 @@ const needsWriteConfirm = computed(() =>
   isDestructiveMethod(method.value, path.value),
 );
 
+const hasCopyableResponse = computed(() =>
+  Boolean((responseText.value || "").trim()),
+);
+
 const persist = () => {
   theSettings.setIndexPlaygroundState(props.indexUid, {
     method: method.value,
@@ -278,11 +336,25 @@ const persist = () => {
   });
 };
 
+const matchActiveTemplate = () => {
+  const match = templates.find(
+    (tpl) =>
+      tpl.method === method.value && tpl.path(props.indexUid) === path.value,
+  );
+  activeTemplateId.value = match?.id || null;
+};
+
+const onRequestEdited = () => {
+  matchActiveTemplate();
+  persist();
+};
+
 const applyTemplate = (tpl) => {
   method.value = tpl.method;
   path.value = tpl.path(props.indexUid);
   body.value = tpl.body || "";
   writeConfirmed.value = false;
+  activeTemplateId.value = tpl.id;
   if (tpl.id === "search") {
     syncBodyToKnobs();
   }
@@ -374,6 +446,18 @@ const sendRequest = async () => {
   }
 };
 
+const copyBody = () =>
+  copyText(body.value, {
+    successMessage: "JSON body copied",
+    emptyMessage: "JSON body is empty",
+  });
+
+const copyResponse = () =>
+  copyText(responseText.value, {
+    successMessage: "Response copied",
+    emptyMessage: "No response to copy yet",
+  });
+
 const copyExport = async (kind, redact) => {
   const req = buildExportRequest({
     host: theSettings.indexUrl,
@@ -387,10 +471,11 @@ const copyExport = async (kind, redact) => {
   if (kind === "curl") text = serializeCurl(req);
   else if (kind === "http") text = serializeHttp(req);
   else text = serializeN8nJson(req);
-  await copyToClipboard(text);
-  showSuccess(
-    redact ? "Copied (redacted Bearer)" : "Copied (includes API key)",
-  );
+  await copyText(text, {
+    successMessage: redact
+      ? "Copied (redacted Bearer)"
+      : "Copied (includes API key)",
+  });
 };
 
 const onKeydown = (e) => {
@@ -415,16 +500,17 @@ const applySeed = (seed) => {
         : JSON.stringify(seed.body || { q: "", limit: 20 }, null, 2);
     syncBodyToKnobs();
   }
+  matchActiveTemplate();
   persist();
 };
 
 onMounted(() => {
   const saved = theSettings.getIndexPlaygroundState(props.indexUid);
   method.value = saved.method || "POST";
-  path.value =
-    saved.path || `/indexes/${props.indexUid}/search`;
+  path.value = saved.path || `/indexes/${props.indexUid}/search`;
   body.value = saved.body || '{\n  "q": "",\n  "limit": 20\n}';
   syncBodyToKnobs();
+  matchActiveTemplate();
 
   const seed = theSettings.consumePlaygroundSeed();
   if (seed) applySeed(seed);
@@ -441,6 +527,7 @@ watch(
     writeConfirmed.value = false;
     responseText.value = "";
     responseMeta.value = null;
+    matchActiveTemplate();
   },
 );
 

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -109,7 +109,10 @@
           label="Copy n8n JSON"
           @click="copyExport('n8n', true)"
         >
-          <q-tooltip>Copy n8n node JSON with API key redacted</q-tooltip>
+          <q-tooltip>
+            Paste into n8n canvas (Ctrl/Cmd+V). HTTP Request node; Bearer
+            redacted.
+          </q-tooltip>
         </q-btn>
         <q-btn
           outline
@@ -122,7 +125,9 @@
           label="n8n + key"
           @click="copyExport('n8n', false)"
         >
-          <q-tooltip>Includes API key. Share carefully.</q-tooltip>
+          <q-tooltip>
+            Paste into n8n canvas. Includes API key. Share carefully.
+          </q-tooltip>
         </q-btn>
       </div>
     </div>

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -15,13 +15,13 @@
           square
           no-caps
           size="sm"
-          color="primary"
           :unelevated="activeTemplateId === tpl.id"
           :outline="activeTemplateId !== tpl.id"
+          :color="activeTemplateId === tpl.id ? 'primary' : undefined"
           :class="
             activeTemplateId === tpl.id
               ? 'bg-primary text-on-primary'
-              : 'border-border'
+              : 'border-border text-text'
           "
           :label="tpl.label"
           @click="applyTemplate(tpl)"
@@ -55,9 +55,9 @@
     </div>
 
     <div
-      class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated p-2"
+      class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated px-2 py-1.5"
     >
-      <span class="text-caption text-text-muted">Export</span>
+      <span class="text-caption text-text-muted">Export for n8n / curl</span>
       <div class="flex flex-wrap items-stretch gap-1">
         <q-btn
           outline
@@ -65,8 +65,7 @@
           square
           no-caps
           size="sm"
-          color="primary"
-          class="border-border"
+          class="border-border text-text"
           label="Copy curl"
           @click="copyExport('curl', true)"
         >
@@ -78,12 +77,14 @@
           square
           no-caps
           size="sm"
-          color="primary"
-          class="border-border"
+          class="border-border text-text"
           label="curl + key"
           @click="copyExport('curl', false)"
         >
-          <q-tooltip>Includes API key. Share carefully.</q-tooltip>
+          <q-tooltip>
+            curl including the API key. Share carefully; do not paste into
+            public channels.
+          </q-tooltip>
         </q-btn>
         <q-btn
           outline
@@ -91,8 +92,7 @@
           square
           no-caps
           size="sm"
-          color="primary"
-          class="border-border"
+          class="border-border text-text"
           label="Copy HTTP"
           @click="copyExport('http', true)"
         >
@@ -104,8 +104,7 @@
           square
           no-caps
           size="sm"
-          color="primary"
-          class="border-border"
+          class="border-border text-text"
           label="Copy n8n JSON"
           @click="copyExport('n8n', true)"
         >
@@ -120,13 +119,13 @@
           square
           no-caps
           size="sm"
-          color="primary"
-          class="border-border"
+          class="border-border text-text"
           label="n8n + key"
           @click="copyExport('n8n', false)"
         >
           <q-tooltip>
-            Paste into n8n canvas. Includes API key. Share carefully.
+            n8n HTTP Request node including the API key. Share carefully; do
+            not paste into public workflows.
           </q-tooltip>
         </q-btn>
       </div>
@@ -137,7 +136,10 @@
     >
       <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
         <q-card-section class="pb-2">
-          <div class="text-subtitle2 font-semibold mb-3">Request</div>
+          <div class="text-subtitle2 font-semibold mb-1">Request</div>
+          <div class="text-caption text-text-muted mb-3">
+            Build method and path, then Send.
+          </div>
           <q-select
             v-model="method"
             :options="methodOptions"
@@ -164,15 +166,17 @@
       <q-card flat bordered square class="bg-page-elevated flex flex-col min-h-0">
         <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
           <div class="flex items-center justify-between gap-2 mb-2">
-            <div class="text-subtitle2 font-semibold">Body / knobs</div>
+            <div>
+              <div class="text-subtitle2 font-semibold">Body</div>
+              <div class="text-caption text-text-muted">Request body (JSON)</div>
+            </div>
             <q-btn
               outline
               dense
               square
               no-caps
               size="sm"
-              color="primary"
-              class="border-border"
+              class="border-border text-text"
               icon="content_copy"
               label="Copy"
               :disable="!needsBody || !body.trim()"
@@ -181,64 +185,66 @@
               <q-tooltip>Copy JSON body</q-tooltip>
             </q-btn>
           </div>
-          <div
-            v-if="method === 'POST' && path.includes('/search')"
-            class="grid grid-cols-2 gap-2 mb-3"
-          >
-            <q-input
-              v-model="searchKnobs.q"
-              outlined
-              dense
-              square
-              label="q"
-              hint="Search query"
-              @update:model-value="syncKnobsToBody"
-            />
-            <q-input
-              v-model="searchKnobs.filter"
-              outlined
-              dense
-              square
-              label="filter"
-              hint="Filter expression"
-              @update:model-value="syncKnobsToBody"
-            />
-            <q-input
-              v-model.number="searchKnobs.limit"
-              type="number"
-              outlined
-              dense
-              square
-              label="limit"
-              @update:model-value="syncKnobsToBody"
-            />
-            <q-input
-              v-model.number="searchKnobs.offset"
-              type="number"
-              outlined
-              dense
-              square
-              label="offset"
-              @update:model-value="syncKnobsToBody"
-            />
-            <q-input
-              v-model="searchKnobs.sort"
-              outlined
-              dense
-              square
-              label="sort (comma)"
-              class="col-span-2"
-              @update:model-value="syncKnobsToBody"
-            />
-            <q-input
-              v-model="searchKnobs.attributesToRetrieve"
-              outlined
-              dense
-              square
-              label="attributesToRetrieve (comma)"
-              class="col-span-2"
-              @update:model-value="syncKnobsToBody"
-            />
+          <div v-if="isSearchRequest" class="mb-3">
+            <div class="text-caption text-text-muted font-medium mb-2">
+              Search options
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+              <q-input
+                v-model="searchKnobs.q"
+                outlined
+                dense
+                square
+                label="q"
+                hint="Search query"
+                @update:model-value="syncKnobsToBody"
+              />
+              <q-input
+                v-model="searchKnobs.filter"
+                outlined
+                dense
+                square
+                label="filter"
+                hint="Filter expression"
+                @update:model-value="syncKnobsToBody"
+              />
+              <q-input
+                v-model.number="searchKnobs.limit"
+                type="number"
+                outlined
+                dense
+                square
+                label="limit"
+                @update:model-value="syncKnobsToBody"
+              />
+              <q-input
+                v-model.number="searchKnobs.offset"
+                type="number"
+                outlined
+                dense
+                square
+                label="offset"
+                @update:model-value="syncKnobsToBody"
+              />
+              <q-input
+                v-model="searchKnobs.sort"
+                outlined
+                dense
+                square
+                label="sort (comma)"
+                class="col-span-2"
+                @update:model-value="syncKnobsToBody"
+              />
+              <q-input
+                v-model="searchKnobs.attributesToRetrieve"
+                outlined
+                dense
+                square
+                label="attributesToRetrieve (comma)"
+                class="col-span-2"
+                @update:model-value="syncKnobsToBody"
+              />
+            </div>
           </div>
           <q-input
             v-model="body"
@@ -249,6 +255,7 @@
             autogrow
             class="font-mono text-caption flex-1"
             label="JSON body"
+            :placeholder="bodyPlaceholder"
             :disable="!needsBody"
             @update:model-value="persist"
           />
@@ -259,12 +266,17 @@
         <q-card-section class="pb-2 flex-1 flex flex-col min-h-0">
           <div class="flex items-center justify-between gap-2 mb-2">
             <div class="flex items-center gap-2 min-w-0">
-              <div class="text-subtitle2 font-semibold">Response</div>
-              <div
-                v-if="responseMeta"
-                class="text-caption text-text-muted truncate"
-              >
-                {{ responseMeta.status }} · {{ responseMeta.durationMs }}ms
+              <div>
+                <div class="text-subtitle2 font-semibold">Response</div>
+                <div
+                  v-if="responseMeta"
+                  class="text-caption text-text-muted truncate"
+                >
+                  {{ responseMeta.status }} · {{ responseMeta.durationMs }}ms
+                </div>
+                <div v-else class="text-caption text-text-muted">
+                  Results appear here after Send
+                </div>
               </div>
             </div>
             <q-btn
@@ -273,8 +285,7 @@
               square
               no-caps
               size="sm"
-              color="primary"
-              class="border-border"
+              class="border-border text-text"
               icon="content_copy"
               label="Copy"
               :disable="!hasCopyableResponse"
@@ -284,8 +295,12 @@
             </q-btn>
           </div>
           <pre
-            class="text-caption whitespace-pre-wrap break-all overflow-auto flex-1 min-h-48 bg-page p-3 border border-border"
-            >{{ responseText || "Send a request to see the response." }}</pre
+            class="text-caption whitespace-pre-wrap break-all overflow-auto flex-1 min-h-48 bg-page p-3 border border-border text-text"
+            :class="responseText ? '' : 'text-text-muted'"
+            >{{
+              responseText ||
+              "No response yet. Click Send to run the request."
+            }}</pre
           >
         </q-card-section>
       </q-card>
@@ -351,6 +366,16 @@ const searchKnobs = reactive({
 
 const needsBody = computed(() =>
   ["POST", "PUT", "PATCH"].includes(method.value),
+);
+
+const bodyPlaceholder = computed(() =>
+  needsBody.value
+    ? '{\n  "q": "",\n  "limit": 20\n}'
+    : "No body for this method",
+);
+
+const isSearchRequest = computed(
+  () => method.value === "POST" && path.value.includes("/search"),
 );
 
 const needsWriteConfirm = computed(() =>

--- a/src/components/settings/PresetSelector.vue
+++ b/src/components/settings/PresetSelector.vue
@@ -2,7 +2,7 @@
   <q-card flat bordered class="q-mb-md">
     <q-card-section>
       <div class="flex items-center justify-between q-mb-sm">
-        <div class="text-subtitle1 font-semibold">Quick Presets</div>
+        <div class="mm-section-title text-subtitle1">Quick Presets</div>
         <q-btn flat dense size="sm" icon="info" @click="showInfo = true">
           <q-tooltip>About presets</q-tooltip>
         </q-btn>

--- a/src/components/settings/RelevancyTab.vue
+++ b/src/components/settings/RelevancyTab.vue
@@ -142,7 +142,7 @@
       expand-separator
       icon="inventory_2"
       label="Search Rules Pack (Portable)"
-      header-class="text-text-muted"
+      header-class="text-text font-semibold"
     >
       <q-card flat bordered>
         <q-card-section class="q-gutter-sm">

--- a/src/components/settings/RelevancyTab.vue
+++ b/src/components/settings/RelevancyTab.vue
@@ -34,7 +34,7 @@
         :current-value="modelValue.rankingRules"
       />
     </div>
-    <q-banner class="bg-grey-2 text-grey-9">
+    <q-banner class="bg-page-elevated text-text border border-border">
       <div class="flex items-end gap-2">
         <q-input
           v-model="pinRankField"
@@ -142,11 +142,11 @@
       expand-separator
       icon="inventory_2"
       label="Search Rules Pack (Portable)"
-      header-class="text-grey-7"
+      header-class="text-text-muted"
     >
       <q-card flat bordered>
         <q-card-section class="q-gutter-sm">
-          <div class="text-caption text-grey-7">
+          <div class="text-caption text-text-muted">
             Export/import ranking and related search rules between projects.
           </div>
           <div class="flex gap-2">

--- a/src/components/settings/ReorderDialogs.vue
+++ b/src/components/settings/ReorderDialogs.vue
@@ -4,17 +4,17 @@
     :model-value="showSearchableReorder"
     @update:model-value="emit('update:showSearchableReorder', $event)"
   >
-    <q-card style="min-width: 400px" class="bg-dark">
+    <q-card style="min-width: 400px" class="bg-page-elevated text-text">
       <q-card-section>
         <div class="text-h6">Reorder Searchable Attributes</div>
-        <p class="text-caption text-grey-7">
+        <p class="text-caption text-text-muted">
           <q-icon name="priority_high" size="xs" color="warning" />
           Order matters! Top attributes have higher search priority.
         </p>
       </q-card-section>
 
       <q-card-section class="q-pt-none">
-        <q-banner dense class="bg-info text-white q-mb-md">
+        <q-banner dense class="bg-page text-text border border-border q-mb-md">
           Fields at the top are searched first and matches in them score higher.
           For example: put "title" before "description" if title matches should
           rank higher.
@@ -27,8 +27,7 @@
           <q-item
             v-for="(attr, index) in modelValue.searchableAttributes"
             :key="attr"
-            class="q-mb-xs rounded"
-            :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-grey-2'"
+            class="q-mb-xs bg-page border border-border"
           >
             <q-item-section avatar>
               <q-icon name="drag_indicator" class="handle cursor-move" />
@@ -68,10 +67,10 @@
     :model-value="showRankingReorder"
     @update:model-value="emit('update:showRankingReorder', $event)"
   >
-    <q-card style="min-width: 400px" class="bg-dark">
+    <q-card style="min-width: 400px" class="bg-page-elevated text-text">
       <q-card-section>
         <div class="text-h6">Reorder Ranking Rules</div>
-        <p class="text-caption text-grey-7">
+        <p class="text-caption text-text-muted">
           Drag rules to change priority (top = highest priority)
         </p>
       </q-card-section>
@@ -85,8 +84,7 @@
           <q-item
             v-for="(rule, index) in modelValue.rankingRules"
             :key="rule"
-            class="q-mb-xs rounded"
-            :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-grey-2'"
+            class="q-mb-xs bg-page border border-border"
           >
             <q-item-section avatar>
               <q-icon name="drag_indicator" class="handle cursor-move" />

--- a/src/components/settings/SettingsBanners.vue
+++ b/src/components/settings/SettingsBanners.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Unsaved Changes Warning -->
-  <q-banner v-if="hasUnsavedSettings" class="bg-orange text-white q-mb-md">
+  <q-banner v-if="hasUnsavedSettings" class="bg-warning text-page q-mb-md">
     <template #avatar>
       <q-icon name="edit" size="md" />
     </template>
@@ -13,7 +13,7 @@
   <!-- Re-indexing Warning -->
   <q-banner
     v-if="reindexingFields.length > 0"
-    class="bg-warning text-black q-mb-md"
+    class="bg-warning text-page q-mb-md"
   >
     <template #avatar>
       <q-icon name="warning" size="md" />
@@ -30,7 +30,7 @@
           size="sm"
           dense
           color="warning"
-          text-color="black"
+          text-color="dark"
         >
           {{ field }}
         </q-chip>

--- a/src/components/settings/SynonymsSection.vue
+++ b/src/components/settings/SynonymsSection.vue
@@ -28,11 +28,11 @@
       </div>
     </div>
 
-    <q-banner dense class="bg-info text-white q-mb-md">
+    <q-banner dense class="bg-page-elevated text-text border border-border q-mb-md">
       <div class="text-caption">
         <strong>CSV Format:</strong> Each row should have a key word followed by
         its synonyms. Example:<br />
-        <code class="text-white">phone,mobile,smartphone,cellphone</code>
+        <code class="text-text">phone,mobile,smartphone,cellphone</code>
       </div>
     </q-banner>
 

--- a/src/components/settings/SynonymsSection.vue
+++ b/src/components/settings/SynonymsSection.vue
@@ -2,7 +2,7 @@
   <div>
     <q-separator class="q-my-md" />
     <div class="flex items-center justify-between q-mb-sm">
-      <div class="text-subtitle2">Synonyms</div>
+      <div class="mm-section-title text-subtitle2">Synonyms</div>
       <div class="flex gap-2">
         <q-btn
           flat

--- a/src/components/settings/TypoToleranceSection.vue
+++ b/src/components/settings/TypoToleranceSection.vue
@@ -2,7 +2,7 @@
   <div>
     <q-separator class="q-my-md" />
     <div class="flex items-center justify-between q-mb-sm">
-      <div class="text-subtitle2">
+      <div class="mm-section-title text-subtitle2">
         Typo Tolerance
         <q-badge
           v-if="hasFieldChanged('typoTolerance')"

--- a/src/components/settings/TypoToleranceSection.vue
+++ b/src/components/settings/TypoToleranceSection.vue
@@ -6,7 +6,7 @@
         Typo Tolerance
         <q-badge
           v-if="hasFieldChanged('typoTolerance')"
-          color="orange"
+          color="warning"
           text-color="white"
           label="Modified"
           class="q-ml-xs"

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -69,7 +69,7 @@ h6 {
 }
 
 /*
- * Quasar filled brand buttons default to white label text. Catalog onPrimary
+ * Quasar filled brand surfaces default to white label text. Catalog onPrimary
  * is the accessible ink (black on high-contrast yellow; white on terracotta).
  */
 .q-btn.bg-primary:not(.q-btn--outline):not(.q-btn--flat) {
@@ -83,6 +83,30 @@ h6 {
 
 .q-chip.bg-primary {
   color: var(--color-on-primary);
+}
+
+.q-banner.bg-primary,
+.bg-primary.text-on-primary,
+.text-on-primary {
+  color: var(--color-on-primary) !important;
+}
+
+/* Warning fill: page ink reads on amber/yellow warning tokens across themes. */
+.q-banner.bg-warning {
+  color: var(--color-page) !important;
+}
+
+.q-card.q-card--bordered {
+  border-color: var(--color-border);
+}
+
+/* Placeholders / muted field chrome must clear AA on dark and HC surfaces. */
+.q-field__native::placeholder,
+.q-placeholder,
+textarea::placeholder,
+input::placeholder {
+  color: var(--color-text-muted);
+  opacity: 1;
 }
 
 /*

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -10,8 +10,8 @@ html {
 }
 
 body {
-  background-color: var(--color-page, #1a1714);
-  color: var(--color-text, #ebe6dc);
+  background-color: var(--color-page);
+  color: var(--color-text);
   font-family: "IBM Plex Sans", system-ui, sans-serif;
 }
 
@@ -30,25 +30,37 @@ h5,
 h6 {
   font-family: "IBM Plex Sans", system-ui, sans-serif;
   font-weight: 600;
-  color: var(--color-text, #ebe6dc);
+  color: var(--color-text);
 }
 
 .q-card {
-  background: var(--color-page-elevated, #232019);
+  background: var(--color-page-elevated);
 }
 
 .q-drawer {
-  background: var(--color-page-elevated, #232019);
+  background: var(--color-page-elevated);
 }
 
 .q-header {
-  background: #2c2824;
-  color: var(--color-text, #ebe6dc);
+  background: var(--color-page-elevated);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .q-tooltip {
   max-width: min(20rem, 95vw);
-  border: 1px solid var(--color-border, #3d3830);
+  border: 1px solid var(--color-border);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   line-height: 1.35;
+}
+
+/* High Contrast: thicker chrome borders (color still from catalog vars). */
+[data-theme="high-contrast"] {
+  .q-header,
+  .q-drawer,
+  .q-card,
+  .q-banner,
+  .q-field__control {
+    border-width: 2px;
+  }
 }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -47,6 +47,20 @@ h6 {
   border-bottom: 1px solid var(--color-border);
 }
 
+/*
+ * Quasar defaults q-footer to primary (bright yellow under high-contrast).
+ * Force a thin credit strip: elevated surface + muted ink, never brand fill.
+ */
+.q-footer {
+  background: var(--color-page-elevated) !important;
+  color: var(--color-text-muted) !important;
+  border-top: 1px solid var(--color-border);
+}
+
+.q-footer a {
+  color: var(--color-text);
+}
+
 .q-tooltip {
   max-width: min(20rem, 95vw);
   border: 1px solid var(--color-border);
@@ -83,6 +97,7 @@ h6 {
 /* High Contrast: thicker chrome + clearer field labels/outlines. */
 [data-theme="high-contrast"] {
   .q-header,
+  .q-footer,
   .q-drawer,
   .q-card,
   .q-banner,

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -71,6 +71,15 @@ h6 {
   color: var(--color-on-primary);
 }
 
+/*
+ * Outline context chips (instance/host). Primary-as-text fails AA on dark
+ * elevated chrome; use token ink + border instead.
+ */
+.q-chip.q-chip--outline.chip-context {
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
 /* High Contrast: thicker chrome + clearer field labels/outlines. */
 [data-theme="high-contrast"] {
   .q-header,

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -22,15 +22,79 @@ body {
   min-width: 0;
 }
 
+/*
+ * Typography hierarchy: titles use full-contrast ink + stronger weight.
+ * text-text-muted stays for helper/meta only (captions, host chips, empty states).
+ * Do not paint all headings text-primary (breaks hierarchy; can fail AA).
+ */
 h1,
 h2,
 h3,
+.text-h1,
+.text-h2,
+.text-h3 {
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
 h4,
 h5,
-h6 {
+h6,
+.text-h4,
+.text-h5,
+.text-h6,
+.text-subtitle1,
+.text-subtitle2 {
   font-family: "IBM Plex Sans", system-ui, sans-serif;
   font-weight: 600;
   color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+/* Page titles (Indexes, Keys, Tasks, …) */
+.mm-page-title {
+  color: var(--color-text);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+/* Card / panel section titles (Overview tables, Playground columns, …) */
+.mm-section-title {
+  display: block;
+  color: var(--color-text);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  border-left: 3px solid var(--color-primary);
+  padding-left: 0.625rem;
+}
+
+/*
+ * Small section kickers only (Presets, Jump to, Export).
+ * Primary-tinted label accent; not for main h1–h3 titles.
+ */
+.mm-section-kicker {
+  color: var(--color-primary);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Index workspace tabs: inactive readable; active stays primary indicator */
+.mm-index-tabs {
+  color: var(--color-text);
+}
+
+.mm-index-tabs .q-tab {
+  font-weight: 500;
+}
+
+.mm-index-tabs .q-tab--active {
+  font-weight: 600;
 }
 
 .q-card {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,4 +1,54 @@
-// app global css in SCSS form
+/* House font: IBM Plex Sans (OFL). Matches Weeumson docs shell tokens. */
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap");
 
 // Algolia InstantSearch reset styles
 @import "instantsearch.css/themes/reset.css";
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  background-color: var(--color-page, #1a1714);
+  color: var(--color-text, #ebe6dc);
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+}
+
+.q-layout,
+.q-page-container,
+.q-page {
+  max-width: 100%;
+  min-width: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  font-weight: 600;
+  color: var(--color-text, #ebe6dc);
+}
+
+.q-card {
+  background: var(--color-page-elevated, #232019);
+}
+
+.q-drawer {
+  background: var(--color-page-elevated, #232019);
+}
+
+.q-header {
+  background: #2c2824;
+  color: var(--color-text, #ebe6dc);
+}
+
+.q-tooltip {
+  max-width: min(20rem, 95vw);
+  border: 1px solid var(--color-border, #3d3830);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  line-height: 1.35;
+}

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -54,7 +54,24 @@ h6 {
   line-height: 1.35;
 }
 
-/* High Contrast: thicker chrome borders (color still from catalog vars). */
+/*
+ * Quasar filled brand buttons default to white label text. Catalog onPrimary
+ * is the accessible ink (black on high-contrast yellow; white on terracotta).
+ */
+.q-btn.bg-primary:not(.q-btn--outline):not(.q-btn--flat) {
+  color: var(--color-on-primary) !important;
+}
+
+.q-btn.bg-primary:not(.q-btn--outline):not(.q-btn--flat) .q-icon,
+.q-btn.bg-primary:not(.q-btn--outline):not(.q-btn--flat) .q-spinner {
+  color: inherit;
+}
+
+.q-chip.bg-primary {
+  color: var(--color-on-primary);
+}
+
+/* High Contrast: thicker chrome + clearer field labels/outlines. */
 [data-theme="high-contrast"] {
   .q-header,
   .q-drawer,
@@ -62,5 +79,27 @@ h6 {
   .q-banner,
   .q-field__control {
     border-width: 2px;
+  }
+
+  .q-field__label,
+  .q-field__native,
+  .q-field__prefix,
+  .q-field__suffix,
+  .q-field__marginal {
+    color: var(--color-text);
+  }
+
+  .q-field--outlined .q-field__control:before {
+    border-color: var(--color-border);
+  }
+
+  .q-btn--outline {
+    border-width: 2px;
+  }
+
+  .text-primary,
+  .q-btn--outline.text-primary,
+  .q-btn.q-btn--outline.bg-primary {
+    color: var(--color-primary) !important;
   }
 }

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -1,25 +1,27 @@
-// Quasar SCSS (& Sass) Variables
-// --------------------------------------------------
-// To customize the look and feel of this app, you can override
-// the Sass/SCSS variables found in Quasar's source Sass/SCSS files.
+// Square-only UI: override Quasar defaults
+$generic-border-radius: 0;
+$button-border-radius: 0;
+$button-rounded-border-radius: 0;
+$button-push-border-radius: 0;
 
-// Check documentation for full list of Quasar variables
+// Match app.scss / Google Fonts: IBM Plex Sans
+$typography-font-family: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI",
+  sans-serif;
 
-// Your own variables (that are declared here) and Quasar's own
-// ones will be available out of the box in your .vue/.scss/.sass files
+$primary: #b85538;
+$secondary: #6f7a68;
+$accent: #b8956c;
 
-// It's highly recommended to change the default colors
-// to match your app's branding.
-// Tip: Use the "Theme Builder" on Quasar's documentation website.
+$dark: #2c2824;
+$dark-page: #1a1714;
 
-$primary: #1976d2;
-$secondary: #26a69a;
-$accent: #9c27b0;
+$positive: #5a7a52;
+$negative: #a84335;
+$info: #6b8b9e;
+$warning: #c98838;
 
-$dark: #1a1f2e;
-$dark-page: #151824;
-
-$positive: #21ba45;
-$negative: #c10015;
-$info: #31ccec;
-$warning: #f2c037;
+// Readable dark-theme tooltips
+$tooltip-fontsize: 13px;
+$tooltip-color: #ebe6dc;
+$tooltip-background: #2c2824;
+$tooltip-padding: 8px 12px;

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -8,20 +8,21 @@ $button-push-border-radius: 0;
 $typography-font-family: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI",
   sans-serif;
 
+// Build-time defaults match weeumson-dark (catalog.js). Runtime setCssVar owns live brand.
 $primary: #b85538;
-$secondary: #6f7a68;
+$secondary: #8a9480;
 $accent: #b8956c;
 
-$dark: #2c2824;
+$dark: #232019;
 $dark-page: #1a1714;
 
-$positive: #5a7a52;
-$negative: #a84335;
-$info: #6b8b9e;
-$warning: #c98838;
+$positive: #7a9a70;
+$negative: #d46a5c;
+$info: #7a9eb0;
+$warning: #d4a05a;
 
-// Readable dark-theme tooltips
+// Readable tooltips (colors overridden at runtime via CSS vars where possible)
 $tooltip-fontsize: 13px;
 $tooltip-color: #ebe6dc;
-$tooltip-background: #2c2824;
+$tooltip-background: #232019;
 $tooltip-padding: 8px 12px;

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -3,3 +3,22 @@
 /* Tailwind v4 content configuration */
 @source "../**/*.{vue,js,ts,jsx,tsx}";
 @source "../../index.html";
+
+@custom-variant dark (&:where(.body--dark, .body--dark *, .dark, .dark *));
+
+/* Weeumson docs-style tokens (mirrored; not imported across repos) */
+@theme {
+  --font-display: "IBM Plex Sans", system-ui, sans-serif;
+  --font-body: "IBM Plex Sans", system-ui, sans-serif;
+
+  --color-page: #1a1714;
+  --color-page-elevated: #232019;
+  --color-text: #ebe6dc;
+  --color-text-muted: #9c958a;
+  --color-border: #3d3830;
+  --color-focus-ring: #d4a574;
+
+  --color-primary: #b85538;
+  --color-secondary: #6f7a68;
+  --color-accent: #b8956c;
+}

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -15,7 +15,7 @@
   --color-page-elevated: #232019;
   --color-border: #7a7268;
   --color-text: #ebe6dc;
-  --color-text-muted: #b8b0a4;
+  --color-text-muted: #d4cbc0;
   --color-primary: #b85538;
   --color-secondary: #8a9480;
   --color-accent: #b8956c;

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -6,19 +6,44 @@
 
 @custom-variant dark (&:where(.body--dark, .body--dark *, .dark, .dark *));
 
-/* Weeumson docs-style tokens (mirrored; not imported across repos) */
+/*
+ * First-paint fallbacks = weeumson-dark (catalog.js).
+ * applyTheme() overwrites these on documentElement at boot.
+ */
+:root {
+  --color-page: #1a1714;
+  --color-page-elevated: #232019;
+  --color-border: #7a7268;
+  --color-text: #ebe6dc;
+  --color-text-muted: #b8b0a4;
+  --color-primary: #b85538;
+  --color-secondary: #8a9480;
+  --color-accent: #b8956c;
+  --color-focus-ring: #d4a574;
+  --color-on-primary: #ffffff;
+  --color-positive: #7a9a70;
+  --color-negative: #d46a5c;
+  --color-info: #7a9eb0;
+  --color-warning: #d4a05a;
+}
+
+/* Map utilities (bg-page, text-text-muted, …) to runtime CSS vars */
 @theme {
   --font-display: "IBM Plex Sans", system-ui, sans-serif;
   --font-body: "IBM Plex Sans", system-ui, sans-serif;
 
-  --color-page: #1a1714;
-  --color-page-elevated: #232019;
-  --color-text: #ebe6dc;
-  --color-text-muted: #9c958a;
-  --color-border: #3d3830;
-  --color-focus-ring: #d4a574;
-
-  --color-primary: #b85538;
-  --color-secondary: #6f7a68;
-  --color-accent: #b8956c;
+  --color-page: var(--color-page);
+  --color-page-elevated: var(--color-page-elevated);
+  --color-border: var(--color-border);
+  --color-text: var(--color-text);
+  --color-text-muted: var(--color-text-muted);
+  --color-primary: var(--color-primary);
+  --color-secondary: var(--color-secondary);
+  --color-accent: var(--color-accent);
+  --color-focus-ring: var(--color-focus-ring);
+  --color-on-primary: var(--color-on-primary);
+  --color-positive: var(--color-positive);
+  --color-negative: var(--color-negative);
+  --color-info: var(--color-info);
+  --color-warning: var(--color-warning);
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -14,11 +14,20 @@
         </q-btn>
 
         <q-toolbar-title class="min-w-0 flex-1">
-          <q-btn flat dense no-caps square to="/" class="q-px-sm">
+          <q-btn
+            flat
+            dense
+            no-caps
+            square
+            to="/"
+            class="q-px-sm"
+            aria-label="Home"
+          >
             <img
               class="h-7 w-7 shrink-0"
               src="~assets/meili-logo.svg"
               alt=""
+              aria-hidden="true"
             />
             <span class="ml-2 truncate text-body1 text-weight-medium">{{
               brandLabel
@@ -53,8 +62,12 @@
           outline
           color="warning"
           class="q-mr-sm"
+          clickable
+          to="/instances"
           label="Not connected"
-        />
+        >
+          <q-tooltip>No instance connected. Open Instances to add one.</q-tooltip>
+        </q-chip>
 
         <q-btn
           flat
@@ -83,6 +96,7 @@
                 clickable
                 v-ripple
                 :active="theme.id === themeId"
+                :aria-current="theme.id === themeId ? 'true' : undefined"
                 active-class="bg-page text-primary"
                 @click="selectTheme(theme.id)"
               >

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout view="hHh lpR lFf" class="bg-page">
-    <q-header elevated class="bg-dark text-text">
+    <q-header elevated class="bg-page-elevated text-text">
       <q-toolbar class="min-w-0">
         <q-btn
           flat
@@ -20,14 +20,14 @@
               src="~assets/meili-logo.svg"
               alt=""
             />
-            <span class="ml-2 truncate text-body1 text-weight-medium"
-              >Meilisearch Manager</span
-            >
+            <span class="ml-2 truncate text-body1 text-weight-medium">{{
+              brandLabel
+            }}</span>
           </q-btn>
         </q-toolbar-title>
 
         <q-chip
-          v-if="activeInstance"
+          v-if="activeInstance && $q.screen.gt.xs"
           dense
           square
           outline
@@ -47,7 +47,7 @@
           </q-tooltip>
         </q-chip>
         <q-chip
-          v-else
+          v-else-if="!activeInstance && $q.screen.gt.xs"
           dense
           square
           outline
@@ -62,21 +62,60 @@
           square
           no-caps
           icon="swap_horiz"
-          label="Instance"
+          :label="$q.screen.gt.xs ? 'Instance' : undefined"
           to="/instances"
           class="q-mr-xs"
+          aria-label="Manage instances"
         >
           <q-tooltip>Manage instances</q-tooltip>
         </q-btn>
 
-        <q-btn
-          flat
-          dense
-          square
-          :icon="darkMode ? 'light_mode' : 'dark_mode'"
-          @click="toggleDarkMode"
-        >
-          <q-tooltip>Toggle dark mode</q-tooltip>
+        <q-btn flat dense square icon="palette" aria-label="Theme">
+          <q-tooltip>Theme</q-tooltip>
+          <q-menu square anchor="bottom right" self="top right">
+            <q-list style="min-width: 220px" class="bg-page-elevated text-text">
+              <q-item-label header class="text-caption text-text-muted">
+                Theme
+              </q-item-label>
+              <q-item
+                v-for="theme in themeOptions"
+                :key="theme.id"
+                clickable
+                v-ripple
+                :active="theme.id === themeId"
+                active-class="bg-page text-primary"
+                @click="selectTheme(theme.id)"
+              >
+                <q-item-section avatar>
+                  <div class="flex gap-0.5" aria-hidden="true">
+                    <span
+                      class="inline-block h-4 w-4 border border-border"
+                      :style="{ background: theme.swatches.page }"
+                    />
+                    <span
+                      class="inline-block h-4 w-4 border border-border"
+                      :style="{ background: theme.swatches.primary }"
+                    />
+                    <span
+                      class="inline-block h-4 w-4 border border-border"
+                      :style="{ background: theme.swatches.elevated }"
+                    />
+                  </div>
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label>{{ theme.label }}</q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                  <q-icon
+                    v-if="theme.id === themeId"
+                    name="check"
+                    color="primary"
+                    size="sm"
+                  />
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-menu>
         </q-btn>
       </q-toolbar>
     </q-header>
@@ -125,7 +164,13 @@
 
     <q-page-container>
       <div v-if="!confirmed" class="p-6">
-        <q-card flat bordered square class="bg-page-elevated max-w-xl mx-auto">
+        <q-card
+          v-if="!isInstancesRoute"
+          flat
+          bordered
+          square
+          class="bg-page-elevated max-w-xl mx-auto"
+        >
           <q-card-section>
             <div class="text-h6 mb-2">Connect to Meilisearch</div>
             <p class="text-caption text-text-muted mb-4">
@@ -154,18 +199,31 @@
 <script setup>
 import { ref, computed, watch, onMounted } from "vue";
 import { useRoute } from "vue-router";
+import { useQuasar } from "quasar";
 import { useSettingsStore } from "src/meili-core/stores/settings-store";
 import { storeToRefs } from "pinia";
-import { useQuasar } from "quasar";
+import { themes } from "src/themes/catalog";
+import { applyTheme } from "src/themes/applyTheme";
 
 const $q = useQuasar();
 const route = useRoute();
 const theSettings = useSettingsStore();
-const { confirmed, darkMode, instances, currentInstance, currentIndex } =
+const { confirmed, themeId, instances, currentInstance, currentIndex } =
   storeToRefs(theSettings);
 
-const leftDrawerOpen = ref(true);
+// Overlay drawer starts closed on narrow viewports; desktop keeps it open.
+const leftDrawerOpen = ref($q.screen.gt.sm);
 const miniDrawer = ref(false);
+
+const themeOptions = Object.values(themes).map((theme) => ({
+  id: theme.id,
+  label: theme.label,
+  swatches: {
+    page: theme.tokens.page,
+    primary: theme.tokens.primary,
+    elevated: theme.tokens.pageElevated,
+  },
+}));
 
 const navLinks = [
   { to: "/", label: "Indexes", icon: "storage" },
@@ -207,18 +265,22 @@ const routeIndexUid = computed(() => {
 
 const isInstancesRoute = computed(() => route.path === "/instances");
 
+const brandLabel = computed(() =>
+  $q.screen.gt.xs ? "Meilisearch Manager" : "Meili Manager",
+);
+
 const toggleLeftDrawer = () => {
   leftDrawerOpen.value = !leftDrawerOpen.value;
 };
 
-const toggleDarkMode = () => {
-  theSettings.darkMode = !theSettings.darkMode;
+const selectTheme = (id) => {
+  theSettings.setThemeId(id);
 };
 
-$q.dark.set(darkMode.value);
+applyTheme(themeId.value);
 
-watch(darkMode, (newVal) => {
-  $q.dark.set(newVal);
+watch(themeId, (id) => {
+  applyTheme(id);
 });
 
 onMounted(async () => {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -206,13 +206,13 @@
       class="bg-page-elevated text-text-muted border-t border-border"
     >
       <div class="px-3 py-2 text-center text-caption">
-        Built with mixed feelings by
+        Built by
         <a
           href="https://weeumson.com"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-primary hover:underline"
-          >Weeumson software</a
+          class="text-text font-medium underline"
+          >Weeumson Software</a
         >
       </div>
     </q-footer>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -201,17 +201,14 @@
       <router-view v-else />
     </q-page-container>
 
-    <q-footer
-      bordered
-      class="bg-page-elevated text-text-muted border-t border-border"
-    >
-      <div class="px-3 py-2 text-center text-caption">
+    <q-footer class="bg-page-elevated text-text-muted border-t border-border">
+      <div class="px-3 py-1 text-center text-caption leading-tight">
         Built by
         <a
           href="https://weeumson.com"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-text font-medium underline"
+          class="text-text font-normal underline"
           >Weeumson Software</a
         >
       </div>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,84 +1,211 @@
 <template>
-  <q-layout view="hHh lpR lFf">
-    <q-header elevated class="bg-primary text-white">
-      <q-toolbar>
-        <q-btn dense flat round icon="menu" @click="toggleLeftDrawer" />
-        <q-toolbar-title>
-          <q-btn dense flat to="/">
-            <img style="max-width: 35px" src="~assets/meili-logo.svg" />
-            &nbsp;Meilisearch Manager</q-btn
-          >
-        </q-toolbar-title>
+  <q-layout view="hHh lpR lFf" class="bg-page">
+    <q-header elevated class="bg-dark text-text">
+      <q-toolbar class="min-w-0">
         <q-btn
-          dense
           flat
-          round
+          dense
+          square
+          icon="menu"
+          aria-label="Toggle navigation"
+          @click="toggleLeftDrawer"
+        >
+          <q-tooltip>Toggle navigation</q-tooltip>
+        </q-btn>
+
+        <q-toolbar-title class="min-w-0 flex-1">
+          <q-btn flat dense no-caps square to="/" class="q-px-sm">
+            <img
+              class="h-7 w-7 shrink-0"
+              src="~assets/meili-logo.svg"
+              alt=""
+            />
+            <span class="ml-2 truncate text-body1 text-weight-medium"
+              >Meilisearch Manager</span
+            >
+          </q-btn>
+        </q-toolbar-title>
+
+        <q-chip
+          v-if="activeInstance"
+          dense
+          square
+          outline
+          color="primary"
+          class="q-mr-sm max-w-xs"
+        >
+          <span class="truncate">
+            {{ activeInstance.label }}
+            <span class="text-caption opacity-80"> · {{ shortHost }}</span>
+            <span v-if="routeIndexUid" class="text-caption opacity-80">
+              · {{ routeIndexUid }}</span
+            >
+          </span>
+          <q-tooltip>
+            {{ activeInstance.label }} · {{ activeInstance.indexUrl
+            }}{{ routeIndexUid ? ` · ${routeIndexUid}` : "" }}
+          </q-tooltip>
+        </q-chip>
+        <q-chip
+          v-else
+          dense
+          square
+          outline
+          color="warning"
+          class="q-mr-sm"
+          label="Not connected"
+        />
+
+        <q-btn
+          flat
+          dense
+          square
+          no-caps
+          icon="swap_horiz"
+          label="Instance"
+          to="/instances"
+          class="q-mr-xs"
+        >
+          <q-tooltip>Manage instances</q-tooltip>
+        </q-btn>
+
+        <q-btn
+          flat
+          dense
+          square
           :icon="darkMode ? 'light_mode' : 'dark_mode'"
           @click="toggleDarkMode"
         >
           <q-tooltip>Toggle dark mode</q-tooltip>
         </q-btn>
-        <q-tabs>
-          <!-- Preview mode hidden (alpha feature) -->
-          <!-- <q-route-tab
-            to="/preview"
-            exact
-            name="preview"
-            label="Preview"
-            class="bg-grey-7 text-white"
-          /> -->
-          <q-route-tab to="/keys" exact name="keys" label="Keys" />
-          <q-route-tab
-            to="/dynamic-rules"
-            exact
-            name="dynamic-rules"
-            label="Dynamic rules"
-          />
-          <q-route-tab to="/tasks" exact name="tasks" label="Tasks" />
-        </q-tabs>
       </q-toolbar>
     </q-header>
 
     <q-drawer
       v-model="leftDrawerOpen"
-      side="left"
-      behavior="mobile"
-      :width="350"
+      show-if-above
       bordered
+      :mini="miniDrawer && $q.screen.gt.sm"
+      :width="240"
+      :mini-width="64"
+      class="bg-page-elevated"
     >
-      <!-- drawer content -->
-      <router-view name="side" />
+      <q-list padding class="text-text">
+        <q-item-label header class="text-caption text-text-muted">
+          Navigate
+        </q-item-label>
+
+        <q-item
+          v-for="link in navLinks"
+          :key="link.to"
+          clickable
+          v-ripple
+          :to="link.to"
+          exact
+          active-class="text-primary bg-page"
+        >
+          <q-item-section avatar>
+            <q-icon :name="link.icon" />
+          </q-item-section>
+          <q-item-section>{{ link.label }}</q-item-section>
+        </q-item>
+
+        <q-separator class="q-my-md" />
+
+        <q-item clickable v-ripple @click="miniDrawer = !miniDrawer">
+          <q-item-section avatar>
+            <q-icon
+              :name="miniDrawer ? 'chevron_right' : 'chevron_left'"
+            />
+          </q-item-section>
+          <q-item-section>{{ miniDrawer ? "Expand" : "Collapse" }}</q-item-section>
+        </q-item>
+      </q-list>
     </q-drawer>
 
     <q-page-container>
-      <div v-if="!confirmed">
-        <q-banner class="text-white text-center bg-red">
-          You need to enter and save working credentials in the menu.
-        </q-banner>
+      <div v-if="!confirmed" class="p-6">
+        <q-card flat bordered square class="bg-page-elevated max-w-xl mx-auto">
+          <q-card-section>
+            <div class="text-h6 mb-2">Connect to Meilisearch</div>
+            <p class="text-caption text-text-muted mb-4">
+              Add an instance with a working URL and API key to use Indexes,
+              Keys, Tasks, and Dynamic rules. Credentials stay in this browser
+              only.
+            </p>
+            <q-btn
+              unelevated
+              square
+              no-caps
+              color="primary"
+              icon="cloud"
+              label="Open Instances"
+              to="/instances"
+            />
+          </q-card-section>
+        </q-card>
+        <router-view v-if="isInstancesRoute" />
       </div>
-      <router-view v-else name="main" />
+      <router-view v-else />
     </q-page-container>
-
-    <q-footer elevated class="bg-grey-8 text-white">
-      <q-toolbar>
-        <q-toolbar-title>
-          <q-btn dense flat round icon="menu" @click="toggleLeftDrawer" />
-        </q-toolbar-title>
-      </q-toolbar>
-    </q-footer>
   </q-layout>
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
+import { useRoute } from "vue-router";
 import { useSettingsStore } from "src/meili-core/stores/settings-store";
 import { storeToRefs } from "pinia";
 import { useQuasar } from "quasar";
 
 const $q = useQuasar();
+const route = useRoute();
 const theSettings = useSettingsStore();
-const { confirmed, darkMode } = storeToRefs(theSettings);
-const leftDrawerOpen = ref(false);
+const { confirmed, darkMode, instances, currentInstance, currentIndex } =
+  storeToRefs(theSettings);
+
+const leftDrawerOpen = ref(true);
+const miniDrawer = ref(false);
+
+const navLinks = [
+  { to: "/", label: "Indexes", icon: "storage" },
+  { to: "/instances", label: "Instances", icon: "cloud" },
+  { to: "/keys", label: "Keys", icon: "vpn_key" },
+  { to: "/tasks", label: "Tasks", icon: "checklist" },
+  { to: "/dynamic-rules", label: "Dynamic rules", icon: "rule" },
+];
+
+const activeInstance = computed(() => {
+  if (
+    currentInstance.value === null ||
+    currentInstance.value === undefined ||
+    !instances.value?.length
+  ) {
+    return null;
+  }
+  return instances.value[currentInstance.value] ?? null;
+});
+
+const shortHost = computed(() => {
+  const url = activeInstance.value?.indexUrl;
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+});
+
+const routeIndexUid = computed(() => {
+  return (
+    route.params.uid ||
+    route.params.indexUid ||
+    (route.path.startsWith("/index-details/") ? currentIndex.value : "") ||
+    ""
+  );
+});
+
+const isInstancesRoute = computed(() => route.path === "/instances");
 
 const toggleLeftDrawer = () => {
   leftDrawerOpen.value = !leftDrawerOpen.value;
@@ -88,10 +215,8 @@ const toggleDarkMode = () => {
   theSettings.darkMode = !theSettings.darkMode;
 };
 
-// Initialize dark mode from store on mount
 $q.dark.set(darkMode.value);
 
-// Watch for dark mode changes and update Quasar
 watch(darkMode, (newVal) => {
   $q.dark.set(newVal);
 });

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -40,13 +40,12 @@
           dense
           square
           outline
-          color="primary"
-          class="q-mr-sm max-w-xs"
+          class="q-mr-sm max-w-xs chip-context"
         >
           <span class="truncate">
             {{ activeInstance.label }}
-            <span class="text-caption opacity-80"> · {{ shortHost }}</span>
-            <span v-if="routeIndexUid" class="text-caption opacity-80">
+            <span class="text-caption text-text-muted"> · {{ shortHost }}</span>
+            <span v-if="routeIndexUid" class="text-caption text-text-muted">
               · {{ routeIndexUid }}</span
             >
           </span>
@@ -97,27 +96,21 @@
                 v-ripple
                 :active="theme.id === themeId"
                 :aria-current="theme.id === themeId ? 'true' : undefined"
-                active-class="bg-page text-primary"
+                active-class="bg-page text-text"
                 @click="selectTheme(theme.id)"
               >
                 <q-item-section avatar>
                   <div class="flex gap-0.5" aria-hidden="true">
                     <span
-                      class="inline-block h-4 w-4 border border-border"
-                      :style="{ background: theme.swatches.page }"
-                    />
-                    <span
-                      class="inline-block h-4 w-4 border border-border"
-                      :style="{ background: theme.swatches.primary }"
-                    />
-                    <span
-                      class="inline-block h-4 w-4 border border-border"
-                      :style="{ background: theme.swatches.elevated }"
+                      v-for="(swatch, idx) in theme.swatches"
+                      :key="idx"
+                      class="inline-block h-3.5 w-3.5 border border-border"
+                      :style="{ background: swatch }"
                     />
                   </div>
                 </q-item-section>
                 <q-item-section>
-                  <q-item-label>{{ theme.label }}</q-item-label>
+                  <q-item-label class="text-text">{{ theme.label }}</q-item-label>
                 </q-item-section>
                 <q-item-section side>
                   <q-icon
@@ -232,7 +225,7 @@ import { useRoute } from "vue-router";
 import { useQuasar } from "quasar";
 import { useSettingsStore } from "src/meili-core/stores/settings-store";
 import { storeToRefs } from "pinia";
-import { themes } from "src/themes/catalog";
+import { getThemeSwatches, themes } from "src/themes/catalog";
 import { applyTheme } from "src/themes/applyTheme";
 
 const $q = useQuasar();
@@ -248,11 +241,7 @@ const miniDrawer = ref(false);
 const themeOptions = Object.values(themes).map((theme) => ({
   id: theme.id,
   label: theme.label,
-  swatches: {
-    page: theme.tokens.page,
-    primary: theme.tokens.primary,
-    elevated: theme.tokens.pageElevated,
-  },
+  swatches: getThemeSwatches(theme),
 }));
 
 const navLinks = [

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -179,7 +179,7 @@
           class="bg-page-elevated max-w-xl mx-auto"
         >
           <q-card-section>
-            <div class="text-h6 mb-2">Connect to Meilisearch</div>
+            <div class="mm-page-title text-h6 mb-2">Connect to Meilisearch</div>
             <p class="text-caption text-text-muted mb-4">
               Add an instance with a working URL and API key to use Indexes,
               Keys, Tasks, and Dynamic rules. Credentials stay in this browser

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -207,6 +207,22 @@
       </div>
       <router-view v-else />
     </q-page-container>
+
+    <q-footer
+      bordered
+      class="bg-page-elevated text-text-muted border-t border-border"
+    >
+      <div class="px-3 py-2 text-center text-caption">
+        Built with mixed feelings by
+        <a
+          href="https://weeumson.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-primary hover:underline"
+          >Weeumson software</a
+        >
+      </div>
+    </q-footer>
   </q-layout>
 </template>
 

--- a/src/layouts/PreviewLayout.vue
+++ b/src/layouts/PreviewLayout.vue
@@ -16,7 +16,7 @@
             exact
             name="manager"
             label="To Manager"
-            class="text-white"
+            class="text-on-primary"
           />
         </q-tabs>
       </q-toolbar>
@@ -35,14 +35,14 @@
 
     <q-page-container>
       <div v-if="!previewCurrentIndex">
-        <q-banner class="text-white text-center bg-red">
+        <q-banner class="bg-negative text-on-primary text-center">
           You need to enter and save working credentials in the menu.
         </q-banner>
       </div>
       <router-view v-else name="main" />
     </q-page-container>
 
-    <q-footer elevated class="bg-grey-8 text-white">
+    <q-footer elevated class="bg-page-elevated text-text border-t border-border">
       <q-toolbar>
         <q-toolbar-title>
           <q-btn dense flat round icon="menu" @click="toggleLeftDrawer" />

--- a/src/layouts/PreviewLayout.vue
+++ b/src/layouts/PreviewLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout view="hHh lpR lFf">
-    <q-header elevated class="bg-primary text-white">
+    <q-header elevated class="bg-primary text-on-primary">
       <q-toolbar>
         <q-btn dense flat round icon="menu" @click="toggleLeftDrawer" />
         <q-toolbar-title>

--- a/src/meili-core/README.md
+++ b/src/meili-core/README.md
@@ -59,5 +59,5 @@ Treat these as the public API. Refactor internals freely, but keep these signatu
 - `settings-store`: `validateConnection()`, `getIndexClient(indexName)`, `rawRequest(path, options)`, `getIndexSearchState(indexName)`, `setIndexSearchState(indexName, state)`, `getIndexDisplaySettings(indexName)`, `setIndexDisplaySettings(indexName, settings)`, `getIndexSettingsCache(indexName)`, `setIndexSettingsCache(indexName, settings)`, `setLastIndexVisit(indexUid, tab)`, `getIndexPlaygroundState(indexName)`, `setIndexPlaygroundState(indexName, state)`, `setPlaygroundSeed(seed)`, `consumePlaygroundSeed()`
 - `utils/search-utils`: default search state + hybrid config helpers
 - `utils/display-settings`: list field resolution, document id/title helpers, `DEFAULT_DISPLAY_SETTINGS`, `mergeDisplaySettings()`
-- `utils/playground-request`: URL/curl/HTTP/n8n serialization + `executePlaygroundRequest`
+- `utils/playground-request`: URL/curl/HTTP/n8n (canvas-pasteable HTTP Request node) serialization + `executePlaygroundRequest`
 - `utils/settings-config`: `SETTINGS_METADATA` (drives any settings UI)

--- a/src/meili-core/README.md
+++ b/src/meili-core/README.md
@@ -10,7 +10,7 @@ This is the canonical source of truth for [meili-manager](../../README.md); the 
 meili-core/
   stores/      Pinia stores (settings, indexes, tasks, keys, dynamic-rules, preview)
   services/    Thin Meilisearch REST wrappers (dynamic search rules, experimental features)
-  utils/       Pure helpers (search state, display-settings, settings metadata, version compat, stats, formatting)
+  utils/       Pure helpers (search state, display-settings, playground-request, settings metadata, version compat, stats, formatting)
 ```
 
 Every file imports only `meilisearch`, `jose`, `pinia`, and its siblings (relative paths). Nothing here imports a UI framework, so the folder is portable as-is.
@@ -56,7 +56,8 @@ await useIndexesStore().fetchIndexes();
 
 Treat these as the public API. Refactor internals freely, but keep these signatures:
 
-- `settings-store`: `validateConnection()`, `getIndexClient(indexName)`, `rawRequest(path, options)`, `getIndexSearchState(indexName)`, `setIndexSearchState(indexName, state)`, `getIndexDisplaySettings(indexName)`, `setIndexDisplaySettings(indexName, settings)`, `getIndexSettingsCache(indexName)`, `setIndexSettingsCache(indexName, settings)`
+- `settings-store`: `validateConnection()`, `getIndexClient(indexName)`, `rawRequest(path, options)`, `getIndexSearchState(indexName)`, `setIndexSearchState(indexName, state)`, `getIndexDisplaySettings(indexName)`, `setIndexDisplaySettings(indexName, settings)`, `getIndexSettingsCache(indexName)`, `setIndexSettingsCache(indexName, settings)`, `setLastIndexVisit(indexUid, tab)`, `getIndexPlaygroundState(indexName)`, `setIndexPlaygroundState(indexName, state)`, `setPlaygroundSeed(seed)`, `consumePlaygroundSeed()`
 - `utils/search-utils`: default search state + hybrid config helpers
 - `utils/display-settings`: list field resolution, document id/title helpers, `DEFAULT_DISPLAY_SETTINGS`, `mergeDisplaySettings()`
+- `utils/playground-request`: URL/curl/HTTP/n8n serialization + `executePlaygroundRequest`
 - `utils/settings-config`: `SETTINGS_METADATA` (drives any settings UI)

--- a/src/meili-core/stores/settings-store.js
+++ b/src/meili-core/stores/settings-store.js
@@ -24,6 +24,13 @@ export const useSettingsStore = defineStore("settings", {
     darkMode: true,
     // Unsaved settings tracking
     hasUnsavedSettings: false,
+    // Resume last index workspace visit (Indexes home Continue)
+    lastIndexUid: "",
+    lastIndexTab: "documents",
+    // Per-index Playground request drafts
+    indexPlaygroundState: {}, // { indexName: { method, path, body } }
+    // One-shot seed for Playground (Documents bridge); not persisted
+    playgroundSeed: null, // { type: 'search'|'document', indexUid, documentId?, body? }
   }),
   getters: {
     // Create fresh client on-demand (no caching, no reactivity issues)
@@ -287,6 +294,41 @@ export const useSettingsStore = defineStore("settings", {
     markSettingsSaved() {
       this.hasUnsavedSettings = false;
     },
+
+    setLastIndexVisit(indexUid, tab = "documents") {
+      if (!indexUid) return;
+      this.lastIndexUid = indexUid;
+      this.lastIndexTab = tab || "documents";
+      this.currentIndex = indexUid;
+    },
+
+    getIndexPlaygroundState(indexName) {
+      return (
+        this.indexPlaygroundState[indexName] || {
+          method: "POST",
+          path: `/indexes/${indexName}/search`,
+          body: '{\n  "q": "",\n  "limit": 20\n}',
+        }
+      );
+    },
+
+    setIndexPlaygroundState(indexName, state) {
+      if (!indexName) return;
+      this.indexPlaygroundState[indexName] = {
+        ...this.getIndexPlaygroundState(indexName),
+        ...state,
+      };
+    },
+
+    setPlaygroundSeed(seed) {
+      this.playgroundSeed = seed;
+    },
+
+    consumePlaygroundSeed() {
+      const seed = this.playgroundSeed;
+      this.playgroundSeed = null;
+      return seed;
+    },
   },
   persist: {
     paths: [
@@ -297,8 +339,11 @@ export const useSettingsStore = defineStore("settings", {
       "instances",
       "indexDisplaySettings",
       "indexSearchState",
+      "indexPlaygroundState",
+      "lastIndexUid",
+      "lastIndexTab",
       "darkMode",
-      // Don't persist hasUnsavedSettings - should reset on page load
+      // Don't persist hasUnsavedSettings / playgroundSeed
     ],
     // Exclude runtime state: activeClient, clientError, isConnecting, confirmed
   },

--- a/src/meili-core/stores/settings-store.js
+++ b/src/meili-core/stores/settings-store.js
@@ -7,6 +7,23 @@ import {
   getIndexSettingsWithStats,
 } from "../utils/meili-client";
 
+/** Known theme ids (labels/tokens live in src/themes/catalog.js). */
+const THEME_IDS = [
+  "weeumson-dark",
+  "weeumson-light",
+  "slate-dark",
+  "slate-light",
+  "high-contrast",
+];
+const DEFAULT_THEME_ID = "weeumson-dark";
+const LIGHT_THEME_IDS = new Set(["weeumson-light", "slate-light"]);
+
+function migrateThemeId(data) {
+  if (data?.themeId && THEME_IDS.includes(data.themeId)) return data.themeId;
+  if (data?.darkMode === false) return "weeumson-light";
+  return DEFAULT_THEME_ID;
+}
+
 export const useSettingsStore = defineStore("settings", {
   state: () => ({
     indexUrl: "https://#",
@@ -21,7 +38,7 @@ export const useSettingsStore = defineStore("settings", {
     indexSearchState: {}, // { indexName: { query: '', filters: {}, sort: '', page: 0, filtersVisible: true, ...search options } }
     // Latest Meilisearch index settings fetched or saved in-session
     indexSettingsCache: {}, // { indexName: { filterableAttributes: [], ... } }
-    darkMode: true,
+    themeId: DEFAULT_THEME_ID,
     // Unsaved settings tracking
     hasUnsavedSettings: false,
     // Resume last index workspace visit (Indexes home Continue)
@@ -48,8 +65,14 @@ export const useSettingsStore = defineStore("settings", {
         apiKey: state.indexKey,
       });
     },
+    /** Derived from themeId (legacy darkMode consumers). */
+    darkMode: (state) => !LIGHT_THEME_IDS.has(state.themeId),
   },
   actions: {
+    setThemeId(themeId) {
+      this.themeId = THEME_IDS.includes(themeId) ? themeId : DEFAULT_THEME_ID;
+    },
+
     // Validate connection (separate from client creation)
     async validateConnection() {
       try {
@@ -331,7 +354,7 @@ export const useSettingsStore = defineStore("settings", {
     },
   },
   persist: {
-    paths: [
+    pick: [
       "indexUrl",
       "indexKey",
       "currentIndex",
@@ -342,9 +365,18 @@ export const useSettingsStore = defineStore("settings", {
       "indexPlaygroundState",
       "lastIndexUid",
       "lastIndexTab",
-      "darkMode",
+      "themeId",
       // Don't persist hasUnsavedSettings / playgroundSeed
     ],
+    serializer: {
+      serialize: JSON.stringify,
+      deserialize: (value) => {
+        const data = JSON.parse(value);
+        data.themeId = migrateThemeId(data);
+        delete data.darkMode;
+        return data;
+      },
+    },
     // Exclude runtime state: activeClient, clientError, isConnecting, confirmed
   },
 });

--- a/src/meili-core/utils/meili-compat.js
+++ b/src/meili-core/utils/meili-compat.js
@@ -58,7 +58,10 @@ export const buildCompatibleSearchParams = (state, compat) => {
     params.rankingScoreThreshold = normalizeThreshold(state.rankingScoreThreshold);
   }
   if (compat.supportsHybrid) {
-    params.hybrid = buildHybridConfig(state);
+    const hybrid = buildHybridConfig(state);
+    if (hybrid) {
+      params.hybrid = hybrid;
+    }
   }
 
   return params;

--- a/src/meili-core/utils/playground-request.js
+++ b/src/meili-core/utils/playground-request.js
@@ -1,0 +1,202 @@
+import { normalizeMeiliHost } from "./meili-client";
+
+export const PLAYGROUND_TEMPLATES = [
+  {
+    id: "search",
+    label: "Search",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/search`,
+    body: '{\n  "q": "",\n  "limit": 20\n}',
+  },
+  {
+    id: "get-document",
+    label: "Get document",
+    method: "GET",
+    path: (uid, docId = ":id") =>
+      `/indexes/${uid}/documents/${encodeURIComponent(docId)}`,
+    body: "",
+  },
+  {
+    id: "get-settings",
+    label: "Get settings",
+    method: "GET",
+    path: (uid) => `/indexes/${uid}/settings`,
+    body: "",
+  },
+  {
+    id: "get-stats",
+    label: "Get stats",
+    method: "GET",
+    path: (uid) => `/indexes/${uid}/stats`,
+    body: "",
+  },
+  {
+    id: "add-documents",
+    label: "Add documents",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/documents`,
+    body: "[\n  {}\n]",
+  },
+  {
+    id: "delete-document",
+    label: "Delete document",
+    method: "DELETE",
+    path: (uid, docId = ":id") =>
+      `/indexes/${uid}/documents/${encodeURIComponent(docId)}`,
+    body: "",
+  },
+];
+
+/**
+ * @param {string} host
+ * @param {string} path
+ * @returns {string}
+ */
+export function buildPlaygroundUrl(host, path) {
+  const baseUrl = normalizeMeiliHost(host);
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  return new URL(cleanPath, `${baseUrl}/`).toString();
+}
+
+/**
+ * @param {{ method: string, url: string, headers: Record<string,string>, body?: string }} req
+ * @returns {string}
+ */
+export function serializeCurl(req) {
+  const parts = [`curl -X ${req.method} '${req.url}'`];
+  for (const [key, value] of Object.entries(req.headers || {})) {
+    parts.push(`  -H '${key}: ${value}'`);
+  }
+  if (req.body && ["POST", "PUT", "PATCH"].includes(req.method)) {
+    const escaped = String(req.body).replace(/'/g, `'\\''`);
+    parts.push(`  --data-raw '${escaped}'`);
+  }
+  return parts.join(" \\\n");
+}
+
+/**
+ * @param {{ method: string, url: string, headers: Record<string,string>, body?: string }} req
+ * @returns {string}
+ */
+export function serializeHttp(req) {
+  const lines = [`${req.method} ${req.url}`];
+  for (const [key, value] of Object.entries(req.headers || {})) {
+    lines.push(`${key}: ${value}`);
+  }
+  if (req.body && ["POST", "PUT", "PATCH"].includes(req.method)) {
+    lines.push("");
+    lines.push(String(req.body));
+  }
+  return lines.join("\n");
+}
+
+/**
+ * @param {{ method: string, url: string, headers: Record<string,string>, body?: string }} req
+ * @returns {string}
+ */
+export function serializeN8nJson(req) {
+  const payload = {
+    method: req.method,
+    url: req.url,
+    headers: req.headers || {},
+  };
+  if (req.body && ["POST", "PUT", "PATCH"].includes(req.method)) {
+    try {
+      payload.body = JSON.parse(req.body);
+    } catch {
+      payload.body = req.body;
+    }
+  }
+  return JSON.stringify(payload, null, 2);
+}
+
+/**
+ * @param {{ host: string, apiKey: string, method: string, path: string, body?: string, redact?: boolean }} options
+ */
+export function buildExportRequest(options) {
+  const {
+    host,
+    apiKey,
+    method,
+    path,
+    body = "",
+    redact = true,
+  } = options;
+  const url = buildPlaygroundUrl(host, path);
+  const bearer = redact ? "REDACTED" : apiKey;
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${bearer}`,
+  };
+  const needsBody = ["POST", "PUT", "PATCH"].includes(method);
+  return {
+    method,
+    url,
+    headers,
+    body: needsBody ? body : undefined,
+  };
+}
+
+/**
+ * Execute a raw Meilisearch HTTP request (same auth pattern as settings-store.rawRequest).
+ * @returns {Promise<{ ok: boolean, status: number, durationMs: number, data: any, rawText: string }>}
+ */
+export async function executePlaygroundRequest({
+  host,
+  apiKey,
+  method,
+  path,
+  body = "",
+}) {
+  const url = buildPlaygroundUrl(host, path);
+  const headers = new Headers({
+    "Content-Type": "application/json",
+  });
+  if (apiKey) {
+    headers.set("Authorization", `Bearer ${apiKey}`);
+  }
+
+  const requestOptions = {
+    method,
+    headers,
+  };
+
+  if (["POST", "PUT", "PATCH"].includes(method) && body !== undefined) {
+    requestOptions.body =
+      typeof body === "string" ? body : JSON.stringify(body);
+  }
+
+  const started = performance.now();
+  const response = await fetch(url, requestOptions);
+  const durationMs = Math.round(performance.now() - started);
+  const rawText = await response.text();
+  let data = null;
+  if (rawText) {
+    try {
+      data = JSON.parse(rawText);
+    } catch {
+      data = rawText;
+    }
+  }
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    durationMs,
+    data,
+    rawText,
+  };
+}
+
+export function isDestructiveMethod(method, path = "") {
+  const m = String(method || "").toUpperCase();
+  if (m === "DELETE") return true;
+  if (
+    ["POST", "PUT", "PATCH"].includes(m) &&
+    /\/documents(\/|$|\?)/.test(path) &&
+    !/\/documents\/fetch/.test(path)
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/meili-core/utils/playground-request.js
+++ b/src/meili-core/utils/playground-request.js
@@ -91,23 +91,87 @@ export function serializeHttp(req) {
 }
 
 /**
+ * Build a canvas-pasteable n8n workflow snippet with one HTTP Request node.
+ * Shape matches n8n 1.x paste import (`nodes` + `connections` + `meta.instanceId`).
+ * Parameter names follow `n8n-nodes-base.httpRequest` V3/4.x (typeVersion 4.2).
+ *
  * @param {{ method: string, url: string, headers: Record<string,string>, body?: string }} req
  * @returns {string}
  */
 export function serializeN8nJson(req) {
-  const payload = {
-    method: req.method,
+  const method = String(req.method || "GET").toUpperCase();
+  const needsBody = ["POST", "PUT", "PATCH"].includes(method);
+  const headers = req.headers || {};
+  const authHeader =
+    headers.Authorization || headers.authorization || "Bearer REDACTED";
+
+  /** @type {Record<string, unknown>} */
+  const parameters = {
+    method,
     url: req.url,
-    headers: req.headers || {},
+    authentication: "none",
+    sendHeaders: true,
+    headerParameters: {
+      parameters: [
+        {
+          name: "Authorization",
+          value: authHeader,
+        },
+      ],
+    },
+    // HTTP Request Options.timeout (ms). Meili search/docs can be slow; 30s is
+    // defensive without the 300s runtime fallback used when timeout is omitted.
+    options: {
+      timeout: 30000,
+    },
   };
-  if (req.body && ["POST", "PUT", "PATCH"].includes(req.method)) {
-    try {
-      payload.body = JSON.parse(req.body);
-    } catch {
-      payload.body = req.body;
+
+  if (needsBody && req.body !== undefined && req.body !== null && req.body !== "") {
+    parameters.sendBody = true;
+    parameters.contentType = "json";
+    parameters.specifyBody = "json";
+    // jsonBody is an n8n "json" string field; keep pretty JSON when parseable.
+    if (typeof req.body === "string") {
+      try {
+        parameters.jsonBody = JSON.stringify(JSON.parse(req.body), null, 2);
+      } catch {
+        parameters.jsonBody = req.body;
+      }
+    } else {
+      parameters.jsonBody = JSON.stringify(req.body, null, 2);
     }
   }
-  return JSON.stringify(payload, null, 2);
+
+  const nodeId =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `meili-http-${Date.now()}`;
+
+  const node = {
+    parameters,
+    id: nodeId,
+    name: "Meilisearch Request",
+    type: "n8n-nodes-base.httpRequest",
+    typeVersion: 4.2,
+    position: [0, 0],
+    // Node Settings (not parameters.options): light retry for transient failures.
+    retryOnFail: true,
+    maxTries: 3,
+    waitBetweenTries: 1000,
+  };
+
+  return JSON.stringify(
+    {
+      nodes: [node],
+      connections: {},
+      pinData: {},
+      meta: {
+        instanceId: "meili-manager-playground",
+      },
+    },
+    null,
+    2,
+  );
 }
 
 /**

--- a/src/meili-core/utils/search-utils.js
+++ b/src/meili-core/utils/search-utils.js
@@ -20,15 +20,83 @@ export const DEFAULT_INDEX_SEARCH_STATE = Object.freeze({
   enableHybrid: false,
   hybridEmbedder: "",
   hybridSemanticRatio: null,
+  activeLlmPreset: null,
   filterDensity: "compact",
   filtersPanelWidth: 380,
   detailPanelTab: "documents",
 });
 
+/** Demo hybrid ratios for Documents Advanced search / LLM presets. */
+export const LLM_DEMO_PRESETS = Object.freeze({
+  keyword: {
+    key: "keyword",
+    label: "Keyword-heavy",
+    caption: "Mostly text match (ratio 0.2)",
+    tooltip:
+      "Turns on hybrid search with a low semantic ratio so keyword ranking dominates.",
+    enableHybrid: true,
+    hybridSemanticRatio: 0.2,
+    showRankingScore: true,
+    showRankingScoreDetails: true,
+    showPerformanceDetails: true,
+  },
+  balanced: {
+    key: "balanced",
+    label: "Balanced",
+    caption: "Even mix (ratio 0.5)",
+    tooltip:
+      "Turns on hybrid search with a 50/50 mix of keyword and semantic ranking.",
+    enableHybrid: true,
+    hybridSemanticRatio: 0.5,
+    showRankingScore: true,
+    showRankingScoreDetails: true,
+    showPerformanceDetails: true,
+  },
+  semantic: {
+    key: "semantic",
+    label: "Semantic-heavy",
+    caption: "Mostly meaning match (ratio 0.8)",
+    tooltip:
+      "Turns on hybrid search with a high semantic ratio so embedding similarity dominates.",
+    enableHybrid: true,
+    hybridSemanticRatio: 0.8,
+    showRankingScore: true,
+    showRankingScoreDetails: true,
+    showPerformanceDetails: true,
+  },
+});
+
+export const LLM_DEMO_PRESET_KEYS = Object.freeze(
+  Object.keys(LLM_DEMO_PRESETS),
+);
+
 export const getDefaultIndexSearchState = () => ({
   ...DEFAULT_INDEX_SEARCH_STATE,
   filters: {},
 });
+
+/** Fields written by LLM demo presets (used by Clear / Reset). */
+export const getClearedLlmPresetFields = () => ({
+  activeLlmPreset: null,
+  enableHybrid: DEFAULT_INDEX_SEARCH_STATE.enableHybrid,
+  hybridSemanticRatio: DEFAULT_INDEX_SEARCH_STATE.hybridSemanticRatio,
+  showRankingScore: DEFAULT_INDEX_SEARCH_STATE.showRankingScore,
+  showRankingScoreDetails: DEFAULT_INDEX_SEARCH_STATE.showRankingScoreDetails,
+  showPerformanceDetails: DEFAULT_INDEX_SEARCH_STATE.showPerformanceDetails,
+});
+
+export const getLlmPresetPatch = (presetKey) => {
+  const preset = LLM_DEMO_PRESETS[presetKey];
+  if (!preset) return null;
+  return {
+    activeLlmPreset: preset.key,
+    enableHybrid: preset.enableHybrid,
+    hybridSemanticRatio: preset.hybridSemanticRatio,
+    showRankingScore: preset.showRankingScore,
+    showRankingScoreDetails: preset.showRankingScoreDetails,
+    showPerformanceDetails: preset.showPerformanceDetails,
+  };
+};
 
 export const buildHybridConfig = (state) => {
   if (!state?.enableHybrid) return undefined;

--- a/src/meili-core/utils/search-utils.js
+++ b/src/meili-core/utils/search-utils.js
@@ -75,10 +75,18 @@ export const getDefaultIndexSearchState = () => ({
   filters: {},
 });
 
+/** First configured embedder name from index settings, or empty string. */
+export const getDefaultEmbedderName = (embedders) => {
+  if (!embedders || typeof embedders !== "object") return "";
+  const names = Object.keys(embedders).filter(Boolean);
+  return names[0] || "";
+};
+
 /** Fields written by LLM demo presets (used by Clear / Reset). */
 export const getClearedLlmPresetFields = () => ({
   activeLlmPreset: null,
   enableHybrid: DEFAULT_INDEX_SEARCH_STATE.enableHybrid,
+  hybridEmbedder: DEFAULT_INDEX_SEARCH_STATE.hybridEmbedder,
   hybridSemanticRatio: DEFAULT_INDEX_SEARCH_STATE.hybridSemanticRatio,
   showRankingScore: DEFAULT_INDEX_SEARCH_STATE.showRankingScore,
   showRankingScoreDetails: DEFAULT_INDEX_SEARCH_STATE.showRankingScoreDetails,
@@ -98,15 +106,18 @@ export const getLlmPresetPatch = (presetKey) => {
   };
 };
 
+/**
+ * Build Meilisearch `hybrid` payload. Never returns hybrid without `embedder`
+ * (Meilisearch requires it inside `.queries[].hybrid`).
+ */
 export const buildHybridConfig = (state) => {
   if (!state?.enableHybrid) return undefined;
-  const hybrid = {
+  const embedder = state.hybridEmbedder?.trim();
+  if (!embedder) return undefined;
+  return {
+    embedder,
     semanticRatio: normalizeThreshold(state.hybridSemanticRatio),
   };
-  if (state.hybridEmbedder?.trim()) {
-    hybrid.embedder = state.hybridEmbedder.trim();
-  }
-  return hybrid;
 };
 
 export const buildRefinementListFromFilters = (filters = {}) => {

--- a/src/pages/DocumentDetailPage.vue
+++ b/src/pages/DocumentDetailPage.vue
@@ -1,31 +1,36 @@
 <template>
-  <q-page padding>
+  <q-page padding class="bg-page">
     <div class="flex flex-col gap-4">
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section>
           <div class="flex items-center justify-between gap-4">
             <q-btn
               flat
+              square
+              no-caps
               icon="arrow_back"
               class="flex-shrink-0"
-              :to="`/index-details/${currentIndex}`"
+              :to="`/index-details/${currentIndex}?tab=documents`"
               >Back</q-btn
             >
-            <p class="flex-1 text-center">
-              Document Details for UID
+            <p class="flex-1 text-center text-text">
+              Document details for UID
               <strong>{{ theDocumentUid ?? "???" }}</strong> in
               <strong>{{ currentIndex ?? "???" }}</strong>
             </p>
             <q-btn
-              flat
+              unelevated
+              square
+              no-caps
+              color="primary"
               icon="save"
               class="flex-shrink-0"
               @click="updateDocument"
               >Save</q-btn
             >
           </div>
-          <q-banner class="bg-primary text-white text-center mt-4">
-            Saving a document with the same UID as another will overwrite it!
+          <q-banner square class="bg-primary text-white text-center mt-4">
+            Saving a document with the same UID as another will overwrite it.
           </q-banner>
           <q-input
             v-model="taskMetadata"

--- a/src/pages/DocumentDetailPage.vue
+++ b/src/pages/DocumentDetailPage.vue
@@ -29,7 +29,10 @@
               >Save</q-btn
             >
           </div>
-          <q-banner square class="bg-primary text-on-primary text-center mt-4">
+          <q-banner
+            square
+            class="bg-page-elevated text-text border border-warning text-center mt-4"
+          >
             Saving a document with the same UID as another will overwrite it.
           </q-banner>
           <q-input
@@ -56,6 +59,7 @@
         :mainMenuBar="false"
         :navigationBar="false"
         :statusBar="true"
+        :dark-theme="darkMode"
         v-model:text="theDocumentText"
       />
     </div>
@@ -72,7 +76,7 @@ import VueJsoneditor from "vue3-ts-jsoneditor";
 import { showSuccess, showError } from "src/utils/notifications";
 const theSettings = useSettingsStore();
 const indexesStore = useIndexesStore();
-const { currentIndex } = storeToRefs(theSettings);
+const { currentIndex, darkMode } = storeToRefs(theSettings);
 const route = useRoute();
 const router = useRouter();
 const theDocument = ref({});

--- a/src/pages/DocumentDetailPage.vue
+++ b/src/pages/DocumentDetailPage.vue
@@ -29,7 +29,7 @@
               >Save</q-btn
             >
           </div>
-          <q-banner square class="bg-primary text-white text-center mt-4">
+          <q-banner square class="bg-primary text-on-primary text-center mt-4">
             Saving a document with the same UID as another will overwrite it.
           </q-banner>
           <q-input

--- a/src/pages/DynamicRulesPage.vue
+++ b/src/pages/DynamicRulesPage.vue
@@ -35,7 +35,7 @@
     <q-banner
       v-if="!confirmed"
       square
-      class="bg-negative text-white mb-4"
+      class="bg-negative text-on-primary mb-4"
     >
       Configure Meilisearch credentials on the Instances page first.
     </q-banner>
@@ -43,7 +43,7 @@
     <q-banner
       v-else-if="experimentalFeaturesError"
       rounded
-      class="bg-amber-2 text-amber-10 mb-4"
+      class="bg-page-elevated text-text border border-border mb-4"
     >
       Could not read experimental features:
       {{ experimentalFeaturesError }}. Your server may be older than v1.41 or
@@ -53,9 +53,9 @@
     <q-banner
       v-else-if="dynamicSearchRulesEnabled === false"
       rounded
-      class="bg-amber-2 text-amber-10 mb-4"
+      class="bg-page-elevated text-text border border-border mb-4"
     >
-      <template #avatar><q-icon name="info" color="amber" /></template>
+      <template #avatar><q-icon name="info" color="warning" /></template>
       Dynamic search rules are disabled on this instance. Enable the
       experimental flag to create or apply rules.
       <template #action>
@@ -63,7 +63,7 @@
           flat
           dense
           label="Enable dynamicSearchRules"
-          color="amber"
+          color="warning"
           :loading="enablingFeature"
           @click="enableDynamicRules"
         />
@@ -73,13 +73,13 @@
     <q-banner
       v-else-if="dynamicSearchRulesEnabled === true"
       rounded
-      class="bg-green-2 text-green-10 mb-4"
+      class="bg-page-elevated text-text border border-border mb-4"
     >
       <template #avatar><q-icon name="check_circle" color="positive" /></template>
       Dynamic search rules are <strong>enabled</strong> for this instance.
     </q-banner>
 
-    <q-banner rounded class="bg-grey-2 text-grey-9 mb-4">
+    <q-banner rounded class="bg-page-elevated text-text border border-border mb-4">
       <strong>Priority:</strong> lower numbers win. Same position → ties broken
       by ascending priority. <strong>Conditions:</strong> all must match (AND).
     </q-banner>

--- a/src/pages/DynamicRulesPage.vue
+++ b/src/pages/DynamicRulesPage.vue
@@ -2,7 +2,7 @@
   <q-page class="p-6 bg-page">
     <div class="flex items-center justify-between mb-6 flex-wrap gap-4">
       <div>
-        <h1 class="text-2xl font-semibold text-text">Dynamic search rules</h1>
+        <h1 class="mm-page-title text-2xl">Dynamic search rules</h1>
         <p class="text-sm text-text-muted">
           Experimental: condition-based pinning via Meilisearch
           <code class="text-xs">dynamicSearchRules</code>

--- a/src/pages/DynamicRulesPage.vue
+++ b/src/pages/DynamicRulesPage.vue
@@ -28,7 +28,11 @@
           label="New rule"
           :disable="!canMutateRules"
           @click="openCreate"
-        />
+        >
+          <q-tooltip v-if="!canMutateRules">
+            Connect an instance and enable dynamic search rules first
+          </q-tooltip>
+        </q-btn>
       </div>
     </div>
 
@@ -62,11 +66,17 @@
         <q-btn
           flat
           dense
+          square
+          no-caps
           label="Enable dynamicSearchRules"
           color="warning"
           :loading="enablingFeature"
           @click="enableDynamicRules"
-        />
+        >
+          <q-tooltip
+            >Sets the experimental feature flag on this instance</q-tooltip
+          >
+        </q-btn>
       </template>
     </q-banner>
 
@@ -121,7 +131,9 @@
             :disable="!canLoadRules"
           />
           <q-btn
-            flat
+            outline
+            square
+            no-caps
             color="primary"
             label="Apply filters"
             :disable="!canLoadRules"
@@ -156,9 +168,10 @@
           <q-btn
             dense
             flat
-            round
+            square
             icon="edit"
             color="primary"
+            aria-label="Edit rule"
             :disable="!canMutateRules"
             @click="openEdit(props.row.uid)"
           >
@@ -167,9 +180,10 @@
           <q-btn
             dense
             flat
-            round
+            square
             icon="science"
             color="secondary"
+            aria-label="Test search"
             :disable="!canReadRules || !props.row?.uid"
             @click="openTest(props.row)"
           >
@@ -178,9 +192,10 @@
           <q-btn
             dense
             flat
-            round
+            square
             icon="delete"
             color="negative"
+            aria-label="Delete rule"
             :disable="!canMutateRules"
             @click="confirmDelete(props.row.uid)"
           >

--- a/src/pages/DynamicRulesPage.vue
+++ b/src/pages/DynamicRulesPage.vue
@@ -1,9 +1,9 @@
 <template>
-  <q-page class="p-6">
+  <q-page class="p-6 bg-page">
     <div class="flex items-center justify-between mb-6 flex-wrap gap-4">
       <div>
-        <h1 class="text-2xl font-bold">Dynamic search rules</h1>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h1 class="text-2xl font-semibold text-text">Dynamic search rules</h1>
+        <p class="text-sm text-text-muted">
           Experimental: condition-based pinning via Meilisearch
           <code class="text-xs">dynamicSearchRules</code>
         </p>
@@ -11,6 +11,8 @@
       <div class="flex gap-2 flex-wrap">
         <q-btn
           outline
+          square
+          no-caps
           color="primary"
           icon="refresh"
           label="Refresh"
@@ -18,6 +20,9 @@
           @click="refreshAll"
         />
         <q-btn
+          unelevated
+          square
+          no-caps
           color="primary"
           icon="add"
           label="New rule"
@@ -29,10 +34,10 @@
 
     <q-banner
       v-if="!confirmed"
-      rounded
-      class="bg-red-2 text-red-10 mb-4"
+      square
+      class="bg-negative text-white mb-4"
     >
-      Configure Meilisearch credentials in the sidebar first.
+      Configure Meilisearch credentials on the Instances page first.
     </q-banner>
 
     <q-banner

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -10,7 +10,6 @@
       <q-btn
         class="q-mt-xl"
         color="primary"
-        text-color="white"
         unelevated
         square
         to="/"

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fullscreen bg-blue text-white text-center q-pa-md flex flex-center"
+    class="fullscreen bg-page text-text text-center q-pa-md flex flex-center"
   >
     <div>
       <div style="font-size: 30vh">404</div>
@@ -9,9 +9,10 @@
 
       <q-btn
         class="q-mt-xl"
-        color="white"
-        text-color="blue"
+        color="primary"
+        text-color="white"
         unelevated
+        square
         to="/"
         label="Go Home"
         no-caps

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -18,7 +18,7 @@
           </q-chip>
         </div>
 
-        <div class="text-subtitle1 font-semibold mb-2 dark:text-white">
+        <div class="text-subtitle1 font-semibold mb-2 text-text">
           Field distribution
         </div>
         <q-table
@@ -33,7 +33,7 @@
         />
 
         <div class="flex flex-wrap items-end gap-2 mb-3">
-          <div class="text-subtitle1 font-semibold dark:text-white flex-1">
+          <div class="text-subtitle1 font-semibold text-text flex-1">
             Fields metadata
           </div>
           <q-input

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -26,7 +26,7 @@
           </q-chip>
         </div>
 
-        <div class="text-subtitle1 font-semibold mb-2 text-text">
+        <div class="mm-section-title text-subtitle1 mb-2">
           Field distribution
         </div>
         <q-table
@@ -41,7 +41,7 @@
         />
 
         <div class="flex flex-wrap items-end gap-2 mb-3">
-          <div class="text-subtitle1 font-semibold text-text flex-1">
+          <div class="mm-section-title text-subtitle1 flex-1">
             Fields metadata
           </div>
           <q-input
@@ -240,7 +240,7 @@
     <q-dialog v-model="showBatchFetchDialog" maximized>
       <q-card>
         <q-card-section class="flex items-center justify-between">
-          <div class="text-h6">Fetched Documents by ID</div>
+          <div class="mm-section-title text-h6">Fetched Documents by ID</div>
           <q-btn
             flat
             dense

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -133,7 +133,11 @@
                 :loading="batchFetchLoading"
                 :disable="!meiliCompat.supportsDocumentsFetchByIds"
                 @click="fetchDocumentsByIds"
-              />
+              >
+                <q-tooltip v-if="!meiliCompat.supportsDocumentsFetchByIds">
+                  Fetch by IDs needs a newer Meilisearch version
+                </q-tooltip>
+              </q-btn>
               <q-btn
                 outline
                 dense
@@ -142,7 +146,9 @@
                 icon="add_circle"
                 label="New"
                 :to="`/documents/${currentIndex}/new`"
-              />
+              >
+                <q-tooltip>Create document in full editor</q-tooltip>
+              </q-btn>
             </div>
           </div>
 
@@ -225,7 +231,14 @@
       <q-card>
         <q-card-section class="flex items-center justify-between">
           <div class="text-h6">Fetched Documents by ID</div>
-          <q-btn flat dense icon="close" v-close-popup />
+          <q-btn
+            flat
+            dense
+            square
+            icon="close"
+            aria-label="Close"
+            v-close-popup
+          />
         </q-card-section>
         <q-separator />
         <q-card-section>

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -163,6 +163,7 @@
               :sort-by-items="sortByItems"
               :matching-strategy-options="matchingStrategyOptions"
               :compat="meiliCompat"
+              :available-embedders="availableEmbedders"
               @apply-preset="applyHybridPreset"
               @clear-preset="clearHybridPreset"
             />
@@ -286,6 +287,7 @@ import {
   buildRefinementListFromFilters,
   getLlmPresetPatch,
   getClearedLlmPresetFields,
+  getDefaultEmbedderName,
   LLM_DEMO_PRESETS,
 } from "src/meili-core/utils/search-utils";
 import {
@@ -512,6 +514,7 @@ const persistSearchState = () => {
 };
 
 const persistSearchStateAndRebuild = () => {
+  resolveHybridEmbedderOrDisable();
   persistSearchState();
   rebuildSearchClient();
 };
@@ -632,14 +635,42 @@ const onFilterDensityChange = (density) => {
   persistSearchState();
 };
 
-const hasConfiguredEmbedders = computed(() => {
+const availableEmbedders = computed(() => {
   const embedders = iSettings.value?.embedders;
-  return !!(
-    embedders &&
-    typeof embedders === "object" &&
-    Object.keys(embedders).length > 0
-  );
+  if (!embedders || typeof embedders !== "object") return [];
+  return Object.keys(embedders).filter(Boolean);
 });
+
+const hasConfiguredEmbedders = computed(
+  () => availableEmbedders.value.length > 0,
+);
+
+/**
+ * When hybrid is on, ensure a non-empty embedder (prefer existing, else first
+ * index embedder). If none exist, disable hybrid and optionally notify.
+ */
+const resolveHybridEmbedderOrDisable = ({ notify = true } = {}) => {
+  if (!savedSearchState.value.enableHybrid) return true;
+  const existing = savedSearchState.value.hybridEmbedder?.trim();
+  if (existing) {
+    savedSearchState.value.hybridEmbedder = existing;
+    return true;
+  }
+  const fallback = getDefaultEmbedderName(iSettings.value?.embedders);
+  if (fallback) {
+    savedSearchState.value.hybridEmbedder = fallback;
+    return true;
+  }
+  savedSearchState.value.enableHybrid = false;
+  savedSearchState.value.hybridSemanticRatio = null;
+  savedSearchState.value.activeLlmPreset = null;
+  if (notify) {
+    showError(
+      "Hybrid needs an embedder configured on the index. Configure embedders under Settings (AI) first.",
+    );
+  }
+  return false;
+};
 
 const resolvedListFields = computed(() =>
   resolveListFields({
@@ -779,6 +810,9 @@ const loadInstance = async () => {
   const savedState = theSettings.getIndexSearchState(currentIndex.value);
   savedSearchState.value = { ...getDefaultIndexSearchState(), ...savedState };
   sanitizeSearchStateForCompat();
+  // Quiet: avoid Notify spam on every index load when hybrid was saved without embedder.
+  resolveHybridEmbedderOrDisable({ notify: false });
+  persistSearchState();
   rebuildSearchClient();
   filtersVisible.value = savedState.filtersVisible ?? true;
   filtersPanelWidth.value = savedState.filtersPanelWidth ?? 380;
@@ -845,12 +879,23 @@ const applyHybridPreset = (preset) => {
   }
   const next = getLlmPresetPatch(preset);
   if (!next) return;
+  const embedder =
+    savedSearchState.value.hybridEmbedder?.trim() ||
+    getDefaultEmbedderName(iSettings.value?.embedders);
+  if (!embedder) {
+    showError(
+      "Hybrid needs an embedder configured on the index. Configure embedders under Settings (AI) first.",
+    );
+    return;
+  }
   // Mutate in place so panel v-models keep the same object and update immediately.
-  Object.assign(savedSearchState.value, next);
+  Object.assign(savedSearchState.value, next, {
+    hybridEmbedder: embedder,
+  });
   persistSearchStateAndRebuild();
   const label = LLM_DEMO_PRESETS[preset]?.label || preset;
   showSuccess(
-    `Applied ${label}: hybrid on, semantic ratio ${next.hybridSemanticRatio}.`,
+    `Applied ${label}: hybrid on, embedder "${embedder}", semantic ratio ${next.hybridSemanticRatio}.`,
   );
 };
 

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -164,6 +164,7 @@
               :matching-strategy-options="matchingStrategyOptions"
               :compat="meiliCompat"
               @apply-preset="applyHybridPreset"
+              @clear-preset="clearHybridPreset"
             />
             <q-splitter
               v-if="filtersVisible"
@@ -283,6 +284,9 @@ import {
   normalizeThreshold,
   getDefaultIndexSearchState,
   buildRefinementListFromFilters,
+  getLlmPresetPatch,
+  getClearedLlmPresetFields,
+  LLM_DEMO_PRESETS,
 } from "src/meili-core/utils/search-utils";
 import {
   getCompatFeatures,
@@ -494,6 +498,7 @@ const sanitizeSearchStateForCompat = () => {
     savedSearchState.value.enableHybrid = false;
     savedSearchState.value.hybridEmbedder = "";
     savedSearchState.value.hybridSemanticRatio = null;
+    savedSearchState.value.activeLlmPreset = null;
   }
 };
 
@@ -834,26 +839,25 @@ const fetchDocumentsByIds = async () => {
 const applyHybridPreset = (preset) => {
   if (!meiliCompat.value.supportsHybrid) {
     showError(
-      `Hybrid presets require a newer server version (current: ${meiliCompat.value.versionString}).`,
+      `Hybrid presets require Meilisearch newer than 1.11 (current: ${meiliCompat.value.versionString}).`,
     );
     return;
   }
-  const presets = {
-    keyword: { enableHybrid: true, hybridSemanticRatio: 0.2 },
-    balanced: { enableHybrid: true, hybridSemanticRatio: 0.5 },
-    semantic: { enableHybrid: true, hybridSemanticRatio: 0.8 },
-  };
-  const next = presets[preset];
+  const next = getLlmPresetPatch(preset);
   if (!next) return;
-  savedSearchState.value = {
-    ...savedSearchState.value,
-    ...next,
-    showRankingScore: true,
-    showRankingScoreDetails: true,
-    showPerformanceDetails: true,
-  };
+  // Mutate in place so panel v-models keep the same object and update immediately.
+  Object.assign(savedSearchState.value, next);
   persistSearchStateAndRebuild();
-  showSuccess(`Applied ${preset} LLM demo preset.`);
+  const label = LLM_DEMO_PRESETS[preset]?.label || preset;
+  showSuccess(
+    `Applied ${label}: hybrid on, semantic ratio ${next.hybridSemanticRatio}.`,
+  );
+};
+
+const clearHybridPreset = () => {
+  Object.assign(savedSearchState.value, getClearedLlmPresetFields());
+  persistSearchStateAndRebuild();
+  showSuccess("Cleared LLM demo preset and restored hybrid defaults.");
 };
 
 // Handle search state changes from persistence component
@@ -959,9 +963,26 @@ watch(
     enableHybrid: savedSearchState.value.enableHybrid,
     hybridEmbedder: savedSearchState.value.hybridEmbedder,
     hybridSemanticRatio: savedSearchState.value.hybridSemanticRatio,
+    activeLlmPreset: savedSearchState.value.activeLlmPreset,
     filterDensity: savedSearchState.value.filterDensity,
   }),
   () => {
+    // Keep preset highlight in sync when hybrid fields are edited manually.
+    const key = savedSearchState.value.activeLlmPreset;
+    if (key && LLM_DEMO_PRESETS[key]) {
+      const expected = LLM_DEMO_PRESETS[key];
+      if (
+        !savedSearchState.value.enableHybrid ||
+        Number(savedSearchState.value.hybridSemanticRatio) !==
+          expected.hybridSemanticRatio
+      ) {
+        // Avoid re-entering this watcher via activeLlmPreset itself.
+        if (savedSearchState.value.activeLlmPreset !== null) {
+          savedSearchState.value.activeLlmPreset = null;
+          return;
+        }
+      }
+    }
     persistSearchStateAndRebuild();
   },
   { deep: true },

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -3,16 +3,24 @@
     <IndexDetailTabs v-model="detailPanelTab" class="flex-1 min-h-0">
       <template #overview-tab>
         <div v-if="iStats && iPk" class="flex flex-wrap gap-2 mb-4">
-          <q-chip icon="numbers" color="info" text-color="white">
+          <q-chip
+            square
+            dense
+            outline
+            icon="numbers"
+            class="chip-context"
+          >
             Count: {{ iStats.numberOfDocuments }}
           </q-chip>
-          <q-chip color="grey-8" text-color="white">
+          <q-chip square dense outline class="chip-context">
             Primary key: {{ iPk }}
           </q-chip>
           <q-chip
+            square
+            dense
+            outline
             :icon="iStats.isIndexing ? 'sync' : 'done'"
-            color="secondary"
-            text-color="white"
+            class="chip-context"
           >
             Indexing: {{ iStats.isIndexing }}
           </q-chip>

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page padding class="index-detail-page flex flex-col">
+  <q-page padding class="index-detail-page flex flex-col bg-page">
     <IndexDetailTabs v-model="detailPanelTab" class="flex-1 min-h-0">
       <template #overview-tab>
         <div v-if="iStats && iPk" class="flex flex-wrap gap-2 mb-4">
@@ -80,6 +80,10 @@
         <SettingsForm @settings-updated="onIndexSettingsUpdated" />
       </template>
 
+      <template #playground-tab>
+        <PlaygroundPanel :index-uid="currentIndex || route.params.uid" />
+      </template>
+
       <template #documents-tab>
         <div class="flex flex-col flex-1 min-h-0 p-3 pt-2">
           <div
@@ -100,6 +104,8 @@
               <q-btn
                 flat
                 dense
+                square
+                no-caps
                 icon="filter_list"
                 :label="filtersVisible ? 'Hide filters' : 'Show filters'"
                 @click="filtersVisible = !filtersVisible"
@@ -110,6 +116,7 @@
                 v-model="batchDocumentIdsInput"
                 dense
                 outlined
+                square
                 clearable
                 class="w-64"
                 label="Fetch by IDs"
@@ -118,6 +125,8 @@
               <q-btn
                 flat
                 dense
+                square
+                no-caps
                 color="secondary"
                 icon="list_alt"
                 label="Fetch"
@@ -126,8 +135,10 @@
                 @click="fetchDocumentsByIds"
               />
               <q-btn
-                flat
+                outline
                 dense
+                square
+                no-caps
                 icon="add_circle"
                 label="New"
                 :to="`/documents/${currentIndex}/new`"
@@ -167,11 +178,19 @@
                 </div>
               </template>
               <template #after>
-                <DocumentsHitsColumn v-bind="hitsColumnProps" />
+                <DocumentsHitsColumn
+                  v-bind="hitsColumnProps"
+                  @select="onHitSelect"
+                />
               </template>
             </q-splitter>
-            <DocumentsHitsColumn v-else v-bind="hitsColumnProps" />
+            <DocumentsHitsColumn
+              v-else
+              v-bind="hitsColumnProps"
+              @select="onHitSelect"
+            />
             <AisSearchDiagnostics
+              :index-uid="currentIndex"
               :header-enabled="savedSearchState.includeSearchMetadataHeader"
               :header-value="savedSearchState.searchMetadataHeaderValue"
               :hybrid-enabled="savedSearchState.enableHybrid"
@@ -179,6 +198,7 @@
               :hybrid-semantic-ratio="
                 normalizeThreshold(savedSearchState.hybridSemanticRatio)
               "
+              @open-playground="openSearchInPlayground"
             />
             <ais-configure v-bind="searchParams" />
             <SearchStatePersistence
@@ -189,6 +209,17 @@
         </div>
       </template>
     </IndexDetailTabs>
+
+    <DocumentSidePanel
+      v-model="docPanelOpen"
+      :index-uid="currentIndex || route.params.uid"
+      :document-id="selectedDocumentId"
+      :document="selectedDocument"
+      :show-similar="
+        meiliCompat.supportsSimilarEndpoint && hasConfiguredEmbedders
+      "
+      @open-playground="openDocumentInPlayground"
+    />
 
     <q-dialog v-model="showBatchFetchDialog" maximized>
       <q-card>
@@ -246,15 +277,17 @@ import {
 } from "src/meili-core/utils/meili-compat";
 import { storeToRefs } from "pinia";
 import { onMounted, ref, watch, nextTick, computed, onBeforeUnmount } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import IndexDetailTabs from "components/IndexDetailTabs.vue";
 import SettingsForm from "components/SettingsForm.vue";
+import PlaygroundPanel from "components/playground/PlaygroundPanel.vue";
 import AisSearchDiagnostics from "components/aisComponents/AisSearchDiagnostics.vue";
 import SearchStatePersistence from "components/SearchStatePersistence.vue";
 import SearchExperiencePanel from "components/SearchExperiencePanel.vue";
 import DocumentsFiltersPanel from "components/documents/DocumentsFiltersPanel.vue";
 import DocumentsHitsColumn from "components/documents/DocumentsHitsColumn.vue";
 import DocumentsDisplayMenu from "components/documents/DocumentsDisplayMenu.vue";
+import DocumentSidePanel from "components/documents/DocumentSidePanel.vue";
 import ListFieldsOrderDialog from "components/documents/ListFieldsOrderDialog.vue";
 import {
   resolveListFields,
@@ -266,6 +299,8 @@ import {
 import { showError, showSuccess } from "src/utils/notifications";
 
 const route = useRoute();
+const router = useRouter();
+const VALID_TABS = ["documents", "settings", "playground", "overview"];
 
 const theSettings = useSettingsStore();
 const indexesStore = useIndexesStore();
@@ -325,6 +360,9 @@ const fieldsColumns = [
 ];
 const displaySettings = ref(mergeDisplaySettings());
 const detailPanelTab = ref("documents");
+const docPanelOpen = ref(false);
+const selectedDocument = ref(null);
+const selectedDocumentId = ref("");
 const imageFieldOptions = ref([]);
 const listFieldOptions = ref([]);
 const listColumnOptions = [
@@ -478,6 +516,64 @@ const persistDetailPanelTab = () => {
     ...theSettings.getIndexSearchState(currentIndex.value),
     detailPanelTab: detailPanelTab.value,
   });
+  theSettings.setLastIndexVisit(currentIndex.value, detailPanelTab.value);
+};
+
+const syncTabToRoute = (tab) => {
+  const nextTab = VALID_TABS.includes(tab) ? tab : "documents";
+  if (route.query.tab === nextTab) return;
+  router.replace({
+    query: { ...route.query, tab: nextTab },
+  });
+};
+
+const onHitSelect = ({ item, documentId }) => {
+  selectedDocument.value = item;
+  selectedDocumentId.value = documentId;
+  docPanelOpen.value = true;
+};
+
+const openDocumentInPlayground = (documentId) => {
+  theSettings.setPlaygroundSeed({
+    type: "document",
+    indexUid: currentIndex.value,
+    documentId,
+  });
+  detailPanelTab.value = "playground";
+};
+
+const openSearchInPlayground = (seed) => {
+  theSettings.setPlaygroundSeed(seed);
+  detailPanelTab.value = "playground";
+};
+
+const isTypingTarget = (el) => {
+  if (!el) return false;
+  const tag = el.tagName?.toLowerCase();
+  return (
+    tag === "input" ||
+    tag === "textarea" ||
+    tag === "select" ||
+    el.isContentEditable
+  );
+};
+
+const onDocumentsKeydown = (e) => {
+  if (e.key === "Escape" && docPanelOpen.value) {
+    docPanelOpen.value = false;
+    return;
+  }
+  if (
+    e.key === "/" &&
+    detailPanelTab.value === "documents" &&
+    !isTypingTarget(e.target)
+  ) {
+    e.preventDefault();
+    const input = document.querySelector(
+      ".ais-SearchBox-input, input[type='search']",
+    );
+    input?.focus?.();
+  }
 };
 
 const onListFieldsChange = (nextFields) => {
@@ -668,8 +764,17 @@ const loadInstance = async () => {
   rebuildSearchClient();
   filtersVisible.value = savedState.filtersVisible ?? true;
   filtersPanelWidth.value = savedState.filtersPanelWidth ?? 380;
-  detailPanelTab.value = savedState.detailPanelTab ?? "documents";
+  const queryTab =
+    typeof route.query.tab === "string" && VALID_TABS.includes(route.query.tab)
+      ? route.query.tab
+      : null;
+  detailPanelTab.value =
+    queryTab || savedState.detailPanelTab || "documents";
   previousQuery.value = savedState.query || "";
+  theSettings.setLastIndexVisit(currentIndex.value, detailPanelTab.value);
+  docPanelOpen.value = false;
+  selectedDocument.value = null;
+  selectedDocumentId.value = "";
 
   // Build image field options from all fields
   imageFieldOptions.value = fdRows.value.map((row) => row["Field Name"]);
@@ -761,9 +866,19 @@ watch(filtersVisible, () => {
   }
 });
 
-watch(detailPanelTab, () => {
+watch(detailPanelTab, (tab) => {
   persistDetailPanelTab();
+  syncTabToRoute(tab);
 });
+
+watch(
+  () => route.query.tab,
+  (tab) => {
+    if (typeof tab === "string" && VALID_TABS.includes(tab) && tab !== detailPanelTab.value) {
+      detailPanelTab.value = tab;
+    }
+  },
+);
 
 watch(
   () => savedSearchState.value.filterDensity,
@@ -803,12 +918,15 @@ onMounted(async () => {
   if (!searchClient.value) {
     rebuildSearchClient();
   }
+  syncTabToRoute(detailPanelTab.value);
+  window.addEventListener("keydown", onDocumentsKeydown);
 
   // Set up watchers for search state after component is mounted
   await nextTick();
 });
 
 onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onDocumentsKeydown);
   if (currentIndex.value) {
     persistSearchState();
   }

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -1,283 +1,273 @@
 <template>
-  <q-page class="p-6">
-    <div v-if="confirmed">
-      <!-- Header -->
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h1 class="text-2xl font-bold dark:text-white">Indexes</h1>
-          <p class="text-sm text-gray-600 dark:text-gray-400">
-            {{ indexUrl }}
-          </p>
-          <p
-            v-if="indexesStore.stats.pkgVersion"
-            class="text-xs text-gray-500 dark:text-gray-500 mt-1"
-          >
-            Meilisearch {{ indexesStore.stats.pkgVersion }}
-          </p>
-          <p
-            v-if="indexesStore.stats.lastClusterUpdate"
-            class="text-xs text-gray-500 dark:text-gray-500 mt-0.5"
-          >
-            Stats at
-            {{
-              new Date(indexesStore.stats.lastClusterUpdate).toLocaleString()
-            }}
-          </p>
-        </div>
-        <div class="flex gap-2">
-          <q-btn
-            outline
-            color="primary"
-            icon="refresh"
-            label="Refresh"
-            @click="refresh"
-            :loading="indexesStore.loading"
-          />
-          <q-btn
-            outline
-            color="secondary"
-            icon="download"
-            label="Create Dump"
-            @click="createDump"
-          />
-          <q-btn
-            color="primary"
-            icon="add_box"
-            label="New Index"
-            @click="showCreateDialog = true"
-          />
-        </div>
+  <q-page class="p-6 bg-page">
+    <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-text">Indexes</h1>
+        <p class="text-sm text-text-muted">{{ indexUrl }}</p>
+        <p
+          v-if="indexesStore.stats.pkgVersion"
+          class="text-xs text-text-muted mt-1"
+        >
+          Meilisearch {{ indexesStore.stats.pkgVersion }}
+        </p>
+        <p
+          v-if="indexesStore.stats.lastClusterUpdate"
+          class="text-xs text-text-muted mt-0.5"
+        >
+          Stats at
+          {{
+            new Date(indexesStore.stats.lastClusterUpdate).toLocaleString()
+          }}
+        </p>
       </div>
-
-      <!-- Stats cards -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        <q-card flat bordered>
-          <q-card-section class="text-center">
-            <div class="text-3xl font-bold text-primary">
-              {{ indexesStore.stats.total }}
-            </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              Total Indexes
-            </div>
-          </q-card-section>
-        </q-card>
-
-        <q-card flat bordered>
-          <q-card-section class="text-center">
-            <div class="text-3xl font-bold text-blue-600">
-              {{ indexesStore.stats.totalDocuments.toLocaleString() }}
-            </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              Total Documents
-            </div>
-          </q-card-section>
-        </q-card>
-
-        <q-card flat bordered>
-          <q-card-section class="text-center">
-            <div class="text-3xl font-bold text-amber-700">
-              {{ formatBytes(clusterUsedOrTotalBytes) }}
-            </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              {{ clusterDiskLabel }}
-            </div>
-            <div
-              v-if="clusterAllocatedCaption"
-              class="text-xs text-gray-500 mt-1"
-            >
-              {{ clusterAllocatedCaption }}
-            </div>
-          </q-card-section>
-        </q-card>
-
-        <q-card flat bordered>
-          <q-card-section class="text-center">
-            <div class="text-3xl font-bold text-green-600">
-              {{ indexesStore.stats.recentlyUpdated }}
-            </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              Updated (24h)
-            </div>
-          </q-card-section>
-        </q-card>
+      <div class="flex flex-wrap gap-2">
+        <q-btn
+          v-if="continueTarget"
+          unelevated
+          square
+          no-caps
+          color="primary"
+          icon="play_arrow"
+          :label="`Continue ${continueTarget.uid}`"
+          :to="continueTarget.to"
+        >
+          <q-tooltip
+            >Resume {{ continueTarget.uid }} · {{ continueTarget.tab }}</q-tooltip
+          >
+        </q-btn>
+        <q-btn
+          outline
+          square
+          no-caps
+          color="primary"
+          icon="refresh"
+          label="Refresh"
+          @click="refresh"
+          :loading="indexesStore.loading"
+        />
+        <q-btn
+          outline
+          square
+          no-caps
+          color="secondary"
+          icon="download"
+          label="Create dump"
+          @click="createDump"
+        />
+        <q-btn
+          unelevated
+          square
+          no-caps
+          color="primary"
+          icon="add_box"
+          label="New index"
+          @click="showCreateDialog = true"
+        />
       </div>
+    </div>
 
-      <!-- Search filter -->
-      <q-card flat bordered class="mb-6">
-        <q-card-section class="py-3">
-          <div class="flex items-center gap-3">
-            <q-input
-              v-model="searchFilter"
-              dense
-              outlined
-              placeholder="Search indexes by UID..."
-              clearable
-              class="flex-1"
-            >
-              <template v-slot:prepend>
-                <q-icon name="search" />
-              </template>
-            </q-input>
-            <q-chip square color="grey-2" text-color="dark">
-              {{ filteredIndexes.length }} shown
-            </q-chip>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-card-section class="text-center">
+          <div class="text-3xl font-bold text-primary">
+            {{ indexesStore.stats.total }}
+          </div>
+          <div class="text-sm text-text-muted mt-1">Total indexes</div>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-card-section class="text-center">
+          <div class="text-3xl font-bold text-accent">
+            {{ indexesStore.stats.totalDocuments.toLocaleString() }}
+          </div>
+          <div class="text-sm text-text-muted mt-1">Total documents</div>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-card-section class="text-center">
+          <div class="text-3xl font-bold text-warning">
+            {{ formatBytes(clusterUsedOrTotalBytes) }}
+          </div>
+          <div class="text-sm text-text-muted mt-1">
+            {{ clusterDiskLabel }}
+          </div>
+          <div v-if="clusterAllocatedCaption" class="text-xs text-text-muted mt-1">
+            {{ clusterAllocatedCaption }}
           </div>
         </q-card-section>
       </q-card>
 
-      <!-- Indexes list -->
-      <div v-if="filteredIndexes.length > 0">
-        <q-card flat bordered>
-          <q-list separator>
-            <q-item
-              v-for="index in filteredIndexes"
-              :key="index.uid"
-              class="dark:hover:bg-gray-800"
-            >
-              <q-item-section>
-                <q-item-label class="text-lg font-semibold dark:text-white">
-                  {{ index.uid }}
-                </q-item-label>
-                <q-item-label caption class="dark:text-gray-400">
-                  <span class="mr-4">
-                    <q-icon name="event" size="xs" class="mr-1" />
-                    Created: {{ formatDate(index.createdAt) }}
-                  </span>
-                  <span class="mr-4">
-                    <q-icon name="update" size="xs" class="mr-1" />
-                    Updated: {{ formatDate(index.updatedAt) }}
-                  </span>
-                  <span v-if="index.statsLoadError" class="text-negative">
-                    Stats: unavailable ({{ index.statsLoadError }})
-                  </span>
-                  <span v-else-if="typeof index.numberOfDocuments === 'number'" class="mr-4">
-                    <q-icon name="description" size="xs" class="mr-1" />
-                    {{ index.numberOfDocuments.toLocaleString() }} docs
-                  </span>
-                  <span v-if="typeof index.fieldCount === 'number'" class="mr-4">
-                    <q-icon name="view_column" size="xs" class="mr-1" />
-                    {{ index.fieldCount }} fields
-                  </span>
-                  <span
-                    v-if="index.attrCounts && !index.statsLoadError"
-                    class="block sm:inline mt-1 sm:mt-0 text-gray-500"
-                  >
-                    F {{ formatAttr(index.attrCounts.filterable) }} · S
-                    {{ formatAttr(index.attrCounts.searchable) }} · Sort
-                    {{ formatAttr(index.attrCounts.sortable) }}
-                  </span>
-                  <span
-                    v-if="typeof index.rawDocumentDbSize === 'number'"
-                    class="block sm:inline mt-1 sm:mt-0 text-gray-500"
-                  >
-                    Raw {{ formatBytes(index.rawDocumentDbSize) }}
-                  </span>
-                  <span
-                    v-if="typeof index.avgDocumentSize === 'number'"
-                    class="block sm:inline mt-1 sm:mt-0 text-gray-500"
-                  >
-                    · Avg doc {{ formatBytes(index.avgDocumentSize) }}
-                  </span>
-                </q-item-label>
-                <div class="mt-2 flex flex-wrap gap-2 items-center">
-                  <q-chip
-                    v-if="index.primaryKey"
-                    dense
-                    square
-                    color="blue-1"
-                    text-color="blue-9"
-                    icon="vpn_key"
-                  >
-                    PK: {{ index.primaryKey }}
-                  </q-chip>
-                  <q-chip
-                    v-if="index.isIndexing"
-                    dense
-                    square
-                    color="orange-2"
-                    text-color="orange-10"
-                    icon="hourglass_empty"
-                  >
-                    Indexing…
-                  </q-chip>
-                  <q-chip
-                    v-if="(index.numberOfEmbeddedDocuments ?? 0) > 0"
-                    dense
-                    square
-                    color="purple-2"
-                    text-color="purple-10"
-                    icon="scatter_plot"
-                  >
-                    {{ index.numberOfEmbeddedDocuments }} embedded
-                  </q-chip>
-                </div>
-              </q-item-section>
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-card-section class="text-center">
+          <div class="text-3xl font-bold text-secondary">
+            {{ indexesStore.stats.recentlyUpdated }}
+          </div>
+          <div class="text-sm text-text-muted mt-1">Updated (24h)</div>
+        </q-card-section>
+      </q-card>
+    </div>
 
-              <q-item-section side class="flex-row gap-2">
-                <q-btn
-                  flat
-                  color="primary"
-                  :to="`/index-details/${index.uid}`"
-                  label="Details"
-                  icon="visibility"
-                />
-                <q-btn
-                  flat
-                  dense
-                  round
-                  color="negative"
-                  icon="delete"
-                  @click.stop.prevent="delIndex(index.uid)"
+    <q-card flat bordered square class="bg-page-elevated mb-6">
+      <q-card-section class="py-3">
+        <div class="flex items-center gap-3">
+          <q-input
+            v-model="searchFilter"
+            dense
+            outlined
+            square
+            placeholder="Search indexes by UID..."
+            clearable
+            class="flex-1"
+          >
+            <template v-slot:prepend>
+              <q-icon name="search" />
+            </template>
+          </q-input>
+          <q-chip square color="primary" text-color="white" outline>
+            {{ filteredIndexes.length }} shown
+          </q-chip>
+        </div>
+      </q-card-section>
+    </q-card>
+
+    <div v-if="filteredIndexes.length > 0">
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-list separator>
+          <q-item
+            v-for="index in filteredIndexes"
+            :key="index.uid"
+            class="hover:bg-page"
+          >
+            <q-item-section>
+              <q-item-label class="text-lg font-semibold text-text">
+                {{ index.uid }}
+              </q-item-label>
+              <q-item-label caption class="text-text-muted">
+                <span class="mr-4">
+                  <q-icon name="event" size="xs" class="mr-1" />
+                  Created: {{ formatDate(index.createdAt) }}
+                </span>
+                <span class="mr-4">
+                  <q-icon name="update" size="xs" class="mr-1" />
+                  Updated: {{ formatDate(index.updatedAt) }}
+                </span>
+                <span v-if="index.statsLoadError" class="text-negative">
+                  Stats: unavailable ({{ index.statsLoadError }})
+                </span>
+                <span
+                  v-else-if="typeof index.numberOfDocuments === 'number'"
+                  class="mr-4"
                 >
-                  <q-tooltip>Delete Index</q-tooltip>
-                </q-btn>
-              </q-item-section>
-            </q-item>
-          </q-list>
-        </q-card>
-      </div>
+                  <q-icon name="description" size="xs" class="mr-1" />
+                  {{ index.numberOfDocuments.toLocaleString() }} docs
+                </span>
+                <span v-if="typeof index.fieldCount === 'number'" class="mr-4">
+                  <q-icon name="view_column" size="xs" class="mr-1" />
+                  {{ index.fieldCount }} fields
+                </span>
+                <span
+                  v-if="index.attrCounts && !index.statsLoadError"
+                  class="block sm:inline mt-1 sm:mt-0 text-text-muted"
+                >
+                  F {{ formatAttr(index.attrCounts.filterable) }} · S
+                  {{ formatAttr(index.attrCounts.searchable) }} · Sort
+                  {{ formatAttr(index.attrCounts.sortable) }}
+                </span>
+                <span
+                  v-if="typeof index.rawDocumentDbSize === 'number'"
+                  class="block sm:inline mt-1 sm:mt-0 text-text-muted"
+                >
+                  Raw {{ formatBytes(index.rawDocumentDbSize) }}
+                </span>
+                <span
+                  v-if="typeof index.avgDocumentSize === 'number'"
+                  class="block sm:inline mt-1 sm:mt-0 text-text-muted"
+                >
+                  · Avg doc {{ formatBytes(index.avgDocumentSize) }}
+                </span>
+              </q-item-label>
+              <div class="mt-2 flex flex-wrap gap-2 items-center">
+                <q-chip
+                  v-if="index.primaryKey"
+                  dense
+                  square
+                  outline
+                  color="primary"
+                  icon="vpn_key"
+                >
+                  PK: {{ index.primaryKey }}
+                </q-chip>
+                <q-chip
+                  v-if="index.isIndexing"
+                  dense
+                  square
+                  color="warning"
+                  text-color="dark"
+                  icon="hourglass_empty"
+                >
+                  Indexing…
+                </q-chip>
+                <q-chip
+                  v-if="(index.numberOfEmbeddedDocuments ?? 0) > 0"
+                  dense
+                  square
+                  outline
+                  color="accent"
+                  icon="scatter_plot"
+                >
+                  {{ index.numberOfEmbeddedDocuments }} embedded
+                </q-chip>
+              </div>
+            </q-item-section>
 
-      <!-- Empty state -->
-      <div v-else class="text-center py-12">
-        <q-icon
-          name="inbox"
-          size="64px"
-          class="text-gray-400 dark:text-gray-600"
-        />
-        <p class="text-gray-600 dark:text-gray-400 mt-4">
-          {{
-            searchFilter
-              ? "No indexes match your search"
-              : "No indexes yet. Create one to get started!"
-          }}
-        </p>
-      </div>
+            <q-item-section side class="flex-row gap-2">
+              <q-btn
+                flat
+                square
+                no-caps
+                color="primary"
+                :to="`/index-details/${index.uid}`"
+                label="Open"
+                icon="visibility"
+              />
+              <q-btn
+                flat
+                dense
+                square
+                color="negative"
+                icon="delete"
+                @click.stop.prevent="delIndex(index.uid)"
+              >
+                <q-tooltip>Delete index</q-tooltip>
+              </q-btn>
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card>
     </div>
 
-    <!-- Not configured state -->
-    <div v-else class="flex items-center justify-center h-96">
-      <div class="text-center">
-        <q-icon
-          name="settings"
-          size="64px"
-          class="text-gray-400 dark:text-gray-600"
-        />
-        <p class="text-gray-600 dark:text-gray-400 mt-4">
-          Please configure your Meilisearch instance in the sidebar
-        </p>
-      </div>
+    <div v-else class="text-center py-12">
+      <q-icon name="inbox" size="64px" class="text-text-muted" />
+      <p class="text-text-muted mt-4">
+        {{
+          searchFilter
+            ? "No indexes match your search"
+            : "No indexes yet. Create one to get started."
+        }}
+      </p>
     </div>
 
-    <!-- Create Index Dialog -->
     <q-dialog v-model="showCreateDialog" persistent>
-      <q-card class="min-w-[400px]">
+      <q-card square class="min-w-[400px] bg-page-elevated">
         <q-card-section
           class="bg-primary text-white flex justify-between items-center"
         >
-          <div class="text-h6">Create New Index</div>
+          <div class="text-h6">Create new index</div>
           <q-btn
             flat
-            round
+            square
             dense
             icon="close"
             @click="showCreateDialog = false"
@@ -289,22 +279,29 @@
             v-model="newIndexName"
             label="Index UID"
             hint="Unique identifier for the index"
-            filled
+            outlined
+            dense
+            square
             :rules="[(val) => (val && val.length > 0) || 'Required']"
           />
           <q-input
             v-model="newIndexUuid"
-            label="Primary Key (Optional)"
+            label="Primary key (optional)"
             hint="Field name to use as document ID"
-            filled
+            outlined
+            dense
+            square
           />
         </q-card-section>
 
         <q-card-actions align="right">
-          <q-btn flat label="Cancel" @click="showCreateDialog = false" />
+          <q-btn flat square no-caps label="Cancel" @click="showCreateDialog = false" />
           <q-btn
+            unelevated
+            square
+            no-caps
             color="primary"
-            label="Create Index"
+            label="Create index"
             @click="newIndex"
             :loading="indexesStore.loading"
           />
@@ -317,7 +314,7 @@
       :scroll-offset="150"
       :offset="[18, 18]"
     >
-      <q-btn fab icon="keyboard_arrow_up" color="accent" />
+      <q-btn fab square icon="keyboard_arrow_up" color="accent" />
     </q-page-scroller>
   </q-page>
 </template>
@@ -340,7 +337,8 @@ const newIndexUuid = ref("");
 const searchFilter = ref("");
 const theSettings = useSettingsStore();
 const indexesStore = useIndexesStore();
-const { indexUrl, confirmed, currentInstance } = storeToRefs(theSettings);
+const { indexUrl, confirmed, currentInstance, lastIndexUid, lastIndexTab } =
+  storeToRefs(theSettings);
 
 const formatDate = (dateString) =>
   new Intl.DateTimeFormat("default", { dateStyle: "long" }).format(
@@ -355,8 +353,28 @@ const formatAttr = (v) => {
   if (typeof v === "number") {
     return String(v);
   }
-  return "—";
+  return "-";
 };
+
+const continueTarget = computed(() => {
+  const uid = lastIndexUid.value;
+  if (!uid) return null;
+  if (
+    indexesStore.indexes.length > 0 &&
+    !indexesStore.indexes.some((idx) => idx.uid === uid)
+  ) {
+    return null;
+  }
+  const tab = lastIndexTab.value || "documents";
+  return {
+    uid,
+    tab,
+    to: {
+      path: `/index-details/${uid}`,
+      query: { tab },
+    },
+  };
+});
 
 /** Prefer used size from GET /stats when the server reports it. */
 const clusterUsedOrTotalBytes = computed(() => {
@@ -389,7 +407,6 @@ const clusterAllocatedCaption = computed(() => {
   return `Allocated ${formatBytes(alloc)}`;
 });
 
-// Filtered indexes based on search
 const filteredIndexes = computed(() => {
   if (!searchFilter.value) return indexesStore.indexes;
 
@@ -438,7 +455,6 @@ const newIndex = async () => {
 
     showSuccess(`Index "${newIndexName.value}" created`);
 
-    // Reset form and close dialog
     newIndexName.value = "";
     newIndexUuid.value = "";
     showCreateDialog.value = false;

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -262,7 +262,7 @@
     <q-dialog v-model="showCreateDialog" persistent>
       <q-card square class="min-w-[400px] bg-page-elevated">
         <q-card-section
-          class="bg-primary text-white flex justify-between items-center"
+          class="bg-primary text-on-primary flex justify-between items-center"
         >
           <div class="text-h6">Create new index</div>
           <q-btn

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -2,7 +2,7 @@
   <q-page class="p-6 bg-page">
     <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-text">Indexes</h1>
+        <h1 class="mm-page-title text-2xl">Indexes</h1>
         <p class="text-sm text-text-muted">{{ indexUrl }}</p>
         <p
           v-if="indexesStore.stats.pkgVersion"

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -53,7 +53,9 @@
           icon="download"
           label="Create dump"
           @click="createDump"
-        />
+        >
+          <q-tooltip>Queue a full database dump (async task)</q-tooltip>
+        </q-btn>
         <q-btn
           unelevated
           square
@@ -118,6 +120,7 @@
             outlined
             square
             placeholder="Search indexes by UID..."
+            aria-label="Search indexes by UID"
             clearable
             class="flex-1"
           >
@@ -174,6 +177,10 @@
                   F {{ formatAttr(index.attrCounts.filterable) }} · S
                   {{ formatAttr(index.attrCounts.searchable) }} · Sort
                   {{ formatAttr(index.attrCounts.sortable) }}
+                  <q-tooltip
+                    >Filterable, searchable, and sortable attribute
+                    counts</q-tooltip
+                  >
                 </span>
                 <span
                   v-if="typeof index.rawDocumentDbSize === 'number'"
@@ -238,6 +245,7 @@
                 square
                 color="negative"
                 icon="delete"
+                aria-label="Delete index"
                 @click.stop.prevent="delIndex(index.uid)"
               >
                 <q-tooltip>Delete index</q-tooltip>
@@ -270,6 +278,7 @@
             square
             dense
             icon="close"
+            aria-label="Close"
             @click="showCreateDialog = false"
           />
         </q-card-section>
@@ -314,7 +323,13 @@
       :scroll-offset="150"
       :offset="[18, 18]"
     >
-      <q-btn fab square icon="keyboard_arrow_up" color="accent" />
+      <q-btn
+        fab
+        square
+        icon="keyboard_arrow_up"
+        color="accent"
+        aria-label="Scroll to top"
+      />
     </q-page-scroller>
   </q-page>
 </template>

--- a/src/pages/InstancesPage.vue
+++ b/src/pages/InstancesPage.vue
@@ -1,0 +1,246 @@
+<template>
+  <q-page class="p-6">
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-text">Instances</h1>
+      <p class="text-sm text-text-muted mt-1">
+        Save and switch Meilisearch endpoints. Credentials stay in this browser.
+      </p>
+      <p v-if="version" class="text-xs text-text-muted mt-1">
+        Active version: {{ version }}
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-card-section>
+          <div class="text-subtitle1 font-semibold mb-4">Add instance</div>
+          <q-form @submit="onSubmit" @reset="onReset" class="space-y-4">
+            <q-input
+              outlined
+              dense
+              square
+              v-model="formLabel"
+              label="Label"
+              hint="e.g. Dev readonly"
+              lazy-rules
+              :rules="[
+                (val) => (val && val.length > 0) || 'Please type something',
+              ]"
+            />
+            <q-input
+              outlined
+              dense
+              square
+              v-model="formUrl"
+              label="Meilisearch URL"
+              hint="https://meili.example.com or http://localhost:7700"
+              lazy-rules
+              :rules="[
+                (val) => (val && val.length > 0) || 'Please type something',
+              ]"
+            />
+            <q-input
+              v-model="formKey"
+              label="API key"
+              outlined
+              dense
+              square
+              :type="isPwd ? 'password' : 'text'"
+              :rules="[
+                (val) => (val && val.length > 0) || 'Please type something',
+              ]"
+            >
+              <template v-slot:append>
+                <q-icon
+                  :name="isPwd ? 'visibility_off' : 'visibility'"
+                  class="cursor-pointer"
+                  @click="isPwd = !isPwd"
+                />
+              </template>
+            </q-input>
+            <div class="flex gap-2">
+              <q-btn
+                unelevated
+                square
+                no-caps
+                label="Add instance"
+                type="submit"
+                color="primary"
+                :loading="isConnecting"
+              />
+              <q-btn
+                flat
+                square
+                no-caps
+                label="Reset"
+                type="reset"
+                color="primary"
+              />
+            </div>
+          </q-form>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered square class="bg-page-elevated">
+        <q-card-section class="pb-0">
+          <div class="flex items-center justify-between">
+            <div class="text-subtitle1 font-semibold">Your instances</div>
+            <a
+              href="https://docs.meilisearch.com/reference/api/keys.html#actions"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-primary text-caption hover:underline"
+            >
+              Permissions docs
+            </a>
+          </div>
+        </q-card-section>
+
+        <q-list v-if="instances.length > 0" separator>
+          <q-item
+            v-for="(value, key) in instances"
+            :key="key"
+            clickable
+            v-ripple
+            :class="{
+              'bg-page text-primary': isActiveInstance(key),
+            }"
+          >
+            <q-item-section @click="selectInstance(key)">
+              <q-item-label class="font-semibold">
+                {{ value?.label ?? "" }}
+              </q-item-label>
+              <q-item-label caption class="text-text-muted">
+                {{ value?.indexUrl ?? "" }}
+              </q-item-label>
+            </q-item-section>
+
+            <q-item-section side class="flex-row gap-1">
+              <q-btn
+                size="sm"
+                flat
+                dense
+                square
+                icon="key"
+                @click="copyKey(key)"
+              >
+                <q-tooltip>Copy API key</q-tooltip>
+              </q-btn>
+              <q-btn
+                size="sm"
+                flat
+                dense
+                square
+                icon="delete"
+                color="negative"
+                @click="deleteInstance(key)"
+              >
+                <q-tooltip>Delete instance</q-tooltip>
+              </q-btn>
+            </q-item-section>
+          </q-item>
+        </q-list>
+
+        <div v-else class="text-center py-10">
+          <q-icon name="cloud_off" size="48px" class="text-text-muted" />
+          <p class="text-text-muted mt-2 text-sm">No instances configured yet</p>
+        </div>
+      </q-card>
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+import { copyToClipboard } from "quasar";
+import { useSettingsStore } from "src/meili-core/stores/settings-store";
+import { computed, ref, watch } from "vue";
+import { storeToRefs } from "pinia";
+import {
+  showSuccess,
+  showError,
+  showConfirmation,
+} from "src/utils/notifications";
+
+const theSettings = useSettingsStore();
+const { currentInstance, instances, confirmed } = storeToRefs(theSettings);
+
+const formLabel = ref("");
+const formUrl = ref("");
+const formKey = ref("");
+const version = ref("");
+const isPwd = ref(true);
+const isConnecting = ref(false);
+
+const isActiveInstance = (instanceKey) =>
+  Number(currentInstance.value) === Number(instanceKey);
+
+const refreshVersion = async () => {
+  if (!confirmed.value) {
+    version.value = "";
+    return;
+  }
+  try {
+    version.value = (await theSettings.client.getVersion()).pkgVersion ?? "";
+  } catch {
+    version.value = "";
+  }
+};
+
+watch(confirmed, () => refreshVersion(), { immediate: true });
+watch(currentInstance, () => refreshVersion());
+
+const onSubmit = async () => {
+  isConnecting.value = true;
+  try {
+    const instanceIndex = await theSettings.addInstance(
+      formLabel.value,
+      formUrl.value,
+      formKey.value,
+    );
+
+    await theSettings.switchInstance(instanceIndex);
+    await refreshVersion();
+    showSuccess("Instance added and activated");
+    onReset();
+  } catch (error) {
+    showError(`Failed to add instance: ${error.message}`);
+  } finally {
+    isConnecting.value = false;
+  }
+};
+
+const onReset = () => {
+  formUrl.value = "";
+  formKey.value = "";
+  formLabel.value = "";
+};
+
+const selectInstance = async (instanceKey) => {
+  try {
+    await theSettings.switchInstance(instanceKey);
+    const inst = instances.value[instanceKey];
+    formLabel.value = inst.label;
+    await refreshVersion();
+    showSuccess(`Switched to ${inst.label}`);
+  } catch (error) {
+    showError(`Failed to switch instance: ${error.message}`);
+  }
+};
+
+const deleteInstance = (instanceKey) => {
+  showConfirmation("Are you sure you want to delete this instance?", () => {
+    try {
+      theSettings.removeInstance(instanceKey);
+      showSuccess("Instance removed");
+    } catch (error) {
+      showError(error.message);
+    }
+  });
+};
+
+const copyKey = async (instanceKey) => {
+  await copyToClipboard(instances.value[instanceKey].indexKey).then(() => {
+    showSuccess("Key copied to clipboard");
+  });
+};
+</script>

--- a/src/pages/InstancesPage.vue
+++ b/src/pages/InstancesPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="p-6">
+  <q-page class="p-6 bg-page">
     <div class="mb-6">
       <h1 class="text-2xl font-semibold text-text">Instances</h1>
       <p class="text-sm text-text-muted mt-1">
@@ -54,6 +54,7 @@
                 <q-icon
                   :name="isPwd ? 'visibility_off' : 'visibility'"
                   class="cursor-pointer"
+                  :aria-label="isPwd ? 'Show API key' : 'Hide API key'"
                   @click="isPwd = !isPwd"
                 />
               </template>
@@ -122,6 +123,7 @@
                 dense
                 square
                 icon="key"
+                aria-label="Copy API key"
                 @click="copyKey(key)"
               >
                 <q-tooltip>Copy API key</q-tooltip>
@@ -133,6 +135,7 @@
                 square
                 icon="delete"
                 color="negative"
+                aria-label="Delete instance"
                 @click="deleteInstance(key)"
               >
                 <q-tooltip>Delete instance</q-tooltip>

--- a/src/pages/InstancesPage.vue
+++ b/src/pages/InstancesPage.vue
@@ -1,7 +1,7 @@
 <template>
   <q-page class="p-6 bg-page">
     <div class="mb-6">
-      <h1 class="text-2xl font-semibold text-text">Instances</h1>
+      <h1 class="mm-page-title text-2xl">Instances</h1>
       <p class="text-sm text-text-muted mt-1">
         Save and switch Meilisearch endpoints. Credentials stay in this browser.
       </p>
@@ -13,7 +13,7 @@
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <q-card flat bordered square class="bg-page-elevated">
         <q-card-section>
-          <div class="text-subtitle1 font-semibold mb-4">Add instance</div>
+          <div class="mm-section-title text-subtitle1 mb-4">Add instance</div>
           <q-form @submit="onSubmit" @reset="onReset" class="space-y-4">
             <q-input
               outlined
@@ -85,7 +85,7 @@
       <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="pb-0">
           <div class="flex items-center justify-between">
-            <div class="text-subtitle1 font-semibold">Your instances</div>
+            <div class="mm-section-title text-subtitle1">Your instances</div>
             <a
               href="https://docs.meilisearch.com/reference/api/keys.html#actions"
               target="_blank"

--- a/src/pages/KeysPage.vue
+++ b/src/pages/KeysPage.vue
@@ -46,9 +46,8 @@
           <div class="text-3xl font-bold text-warning">
             {{ keysStore.stats.expiringSoon }}
           </div>
-          <div class="text-sm text-text-muted">
-            Expiring soon
-          </div>
+          <div class="text-sm text-text-muted">Expiring soon</div>
+          <div class="text-xs text-text-muted mt-1">Within 30 days</div>
         </q-card-section>
       </q-card>
       <q-card flat bordered square class="bg-page-elevated">
@@ -79,6 +78,7 @@
           label="Search keys"
           outlined
           dense
+          square
           clearable
           placeholder="Search by name, description, or UID"
         >
@@ -104,7 +104,7 @@
             expand-separator
             icon="key"
             label="Raw Keys JSON"
-            header-class="text-blue"
+            header-class="text-text-muted"
           >
             <q-card bordered>
               <q-card-section>
@@ -176,16 +176,26 @@
                 />
 
                 <div class="flex justify-between">
-                  <q-btn label="Save" type="submit" color="primary" />
+                  <q-btn
+                    unelevated
+                    square
+                    no-caps
+                    label="Save"
+                    type="submit"
+                    color="primary"
+                  />
                   <q-btn
                     size="14px"
                     flat
-                    bordered
-                    color="red"
+                    square
+                    no-caps
+                    color="negative"
                     icon="delete"
                     label="Delete"
                     @click="delKey(key.uid)"
-                  />
+                  >
+                    <q-tooltip>Delete API key permanently</q-tooltip>
+                  </q-btn>
                 </div>
               </q-form>
 
@@ -276,7 +286,13 @@
         :scroll-offset="150"
         :offset="[18, 18]"
       >
-        <q-btn fab icon="keyboard_arrow_up" color="accent" />
+        <q-btn
+          fab
+          square
+          icon="keyboard_arrow_up"
+          color="accent"
+          aria-label="Scroll to top"
+        />
       </q-page-scroller>
 
       <!-- Create Key Dialog -->
@@ -288,9 +304,10 @@
             <div class="text-h6">Create New API Key</div>
             <q-btn
               flat
-              round
+              square
               dense
               icon="close"
+              aria-label="Close"
               @click="showCreateDialog = false"
             />
           </q-card-section>

--- a/src/pages/KeysPage.vue
+++ b/src/pages/KeysPage.vue
@@ -3,7 +3,7 @@
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-text">API keys</h1>
+        <h1 class="mm-page-title text-2xl">API keys</h1>
         <p class="text-sm text-text-muted">
           Manage Meilisearch API keys and permissions
         </p>
@@ -104,7 +104,7 @@
             expand-separator
             icon="key"
             label="Raw Keys JSON"
-            header-class="text-text-muted"
+            header-class="text-text font-semibold"
           >
             <q-card bordered>
               <q-card-section>

--- a/src/pages/KeysPage.vue
+++ b/src/pages/KeysPage.vue
@@ -1,16 +1,18 @@
 <template>
-  <q-page class="p-6">
+  <q-page class="p-6 bg-page">
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold">API Keys</h1>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h1 class="text-2xl font-semibold text-text">API keys</h1>
+        <p class="text-sm text-text-muted">
           Manage Meilisearch API keys and permissions
         </p>
       </div>
       <div class="flex gap-2">
         <q-btn
           outline
+          square
+          no-caps
           color="primary"
           icon="refresh"
           label="Refresh"
@@ -18,9 +20,12 @@
           :loading="keysStore.loading"
         />
         <q-btn
+          unelevated
+          square
+          no-caps
           color="primary"
           icon="add"
-          label="Create Key"
+          label="Create key"
           @click="showCreateDialog = true"
         />
       </div>
@@ -28,46 +33,46 @@
 
     <!-- Stats cards -->
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-blue-500">
+          <div class="text-3xl font-bold text-primary">
             {{ keysStore.stats.total }}
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">Total Keys</div>
+          <div class="text-sm text-text-muted">Total keys</div>
         </q-card-section>
       </q-card>
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-orange-500">
+          <div class="text-3xl font-bold text-warning">
             {{ keysStore.stats.expiringSoon }}
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">
-            Expiring Soon
+          <div class="text-sm text-text-muted">
+            Expiring soon
           </div>
         </q-card-section>
       </q-card>
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-red-500">
+          <div class="text-3xl font-bold text-negative">
             {{ keysStore.stats.expired }}
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">Expired</div>
+          <div class="text-sm text-text-muted">Expired</div>
         </q-card-section>
       </q-card>
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-green-500">
+          <div class="text-3xl font-bold text-secondary">
             {{ keysStore.stats.neverExpire }}
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">
-            Never Expire
+          <div class="text-sm text-text-muted">
+            Never expire
           </div>
         </q-card-section>
       </q-card>
     </div>
 
     <!-- Search Filter -->
-    <q-card flat bordered class="mb-4">
+    <q-card flat bordered square class="bg-page-elevated mb-4">
       <q-card-section>
         <q-input
           v-model="searchFilter"

--- a/src/pages/KeysPage.vue
+++ b/src/pages/KeysPage.vue
@@ -93,7 +93,7 @@
       <q-card flat bordered>
         <q-card-section>
           <div class="text-center mb-4">
-            <p class="text-lg font-semibold dark:text-gray-200">
+            <p class="text-lg font-semibold text-text">
               {{ filteredKeys.length }} Key{{
                 filteredKeys.length !== 1 ? "s" : ""
               }}
@@ -108,12 +108,12 @@
           >
             <q-card bordered>
               <q-card-section>
-                <p class="text-center mb-4 dark:text-gray-300">
+                <p class="text-center mb-4 text-text-muted">
                   The following is a real time look at your keys objects in
                   full.
                 </p>
                 <pre
-                  class="text-xs overflow-auto bg-gray-900 dark:bg-gray-950 text-white p-4 rounded"
+                  class="text-xs overflow-auto bg-page text-text border border-border p-4"
                   >{{ JSON.stringify(iKeys, null, 2) }}</pre
                 >
               </q-card-section>
@@ -137,7 +137,7 @@
                   <q-icon name="key" size="sm" />
                   <div>
                     <div class="font-semibold">{{ key.name }}</div>
-                    <div class="text-xs text-gray-500 dark:text-gray-400">
+                    <div class="text-xs text-text-muted">
                       UID: {{ key.uid }}
                     </div>
                   </div>
@@ -150,7 +150,7 @@
               </div>
             </template>
             <q-card class="p-6" flat bordered>
-              <p class="text-center font-bold mb-4 dark:text-gray-200">
+              <p class="text-center font-bold mb-4 text-text">
                 {{ key.name }}
               </p>
               <q-form @submit="onSubmit(key.uid)" class="space-y-4">
@@ -191,7 +191,7 @@
 
               <q-separator class="my-6" />
               <div class="text-center mb-4">
-                <p class="font-semibold dark:text-gray-300">
+                <p class="font-semibold text-text-muted">
                   The following key details can only be set at the time of
                   creation
                 </p>
@@ -233,28 +233,28 @@
                 class="mb-4"
               />
               <div class="flex flex-col md:flex-row justify-evenly gap-4 mb-4">
-                <div class="bg-gray-100 dark:bg-gray-800 p-4 rounded flex-1">
-                  <div class="font-semibold mb-2 dark:text-gray-200">
+                <div class="bg-page p-4 border border-border flex-1">
+                  <div class="font-semibold mb-2 text-text">
                     Granted Actions:
                   </div>
-                  <ul class="list-disc list-inside dark:text-gray-300">
+                  <ul class="list-disc list-inside text-text-muted">
                     <template v-for="action in key.actions" :key="action">
                       <li>{{ action }}</li>
                     </template>
                   </ul>
                 </div>
-                <div class="bg-gray-100 dark:bg-gray-800 p-4 rounded flex-1">
-                  <div class="font-semibold mb-2 dark:text-gray-200">
+                <div class="bg-page p-4 border border-border flex-1">
+                  <div class="font-semibold mb-2 text-text">
                     Granted Indexes:
                   </div>
-                  <ul class="list-disc list-inside dark:text-gray-300">
+                  <ul class="list-disc list-inside text-text-muted">
                     <template v-for="idx in key.indexes" :key="idx">
                       <li>{{ idx }}</li>
                     </template>
                   </ul>
                 </div>
               </div>
-              <div class="text-center space-y-2 dark:text-gray-300">
+              <div class="text-center space-y-2 text-text-muted">
                 <p>
                   <strong>Created At:</strong> {{ formatDate(key.createdAt) }}
                 </p>
@@ -283,7 +283,7 @@
       <q-dialog v-model="showCreateDialog" persistent>
         <q-card class="min-w-[500px]">
           <q-card-section
-            class="bg-primary text-white flex justify-between items-center"
+            class="bg-primary text-on-primary flex justify-between items-center"
           >
             <div class="text-h6">Create New API Key</div>
             <q-btn

--- a/src/pages/PreviewPage.vue
+++ b/src/pages/PreviewPage.vue
@@ -32,7 +32,7 @@
                 icon="list"
                 label="Filters"
               >
-                <q-banner class="bg-warning text-black q-mb-md">
+                <q-banner class="bg-warning text-page q-mb-md">
                   Warning - Experimental
                 </q-banner>
                 <q-card

--- a/src/pages/PreviewSidebar.vue
+++ b/src/pages/PreviewSidebar.vue
@@ -110,7 +110,7 @@
     </q-card>
     <div class="text-center text-bold border-bottom my-2">Configuration</div>
     <q-card flat bordered>
-      <q-banner rounded dense class="bg-primary text-white text-bold">
+      <q-banner rounded dense class="bg-primary text-on-primary text-bold">
         Auto filled dropdown values from your index will
         <strong>not work</strong> without the
         <code class="bg-black">settings.get</code>

--- a/src/pages/SidebarSettings.vue
+++ b/src/pages/SidebarSettings.vue
@@ -15,7 +15,9 @@
     <!-- Add Instance Form -->
     <q-form @submit="onSubmit" @reset="onReset" class="space-y-4 mb-6">
       <q-input
-        filled
+        outlined
+        dense
+        square
         v-model="formLabel"
         label="The Label for this instance"
         hint="eg. 'Dev instance readonly'"
@@ -23,7 +25,9 @@
         :rules="[(val) => (val && val.length > 0) || 'Please type something']"
       />
       <q-input
-        filled
+        outlined
+        dense
+        square
         v-model="formUrl"
         label="The MeiliSearch index URL"
         hint="https://myEngine.com"
@@ -33,7 +37,9 @@
       <q-input
         v-model="formKey"
         label="The MeiliSearch index API Key"
-        filled
+        outlined
+        dense
+        square
         :type="isPwd ? 'password' : 'text'"
         :rules="[(val) => (val && val.length > 0) || 'Please type something']"
       >
@@ -41,18 +47,30 @@
           <q-icon
             :name="isPwd ? 'visibility_off' : 'visibility'"
             class="cursor-pointer"
+            :aria-label="isPwd ? 'Show API key' : 'Hide API key'"
             @click="isPwd = !isPwd"
           />
         </template>
       </q-input>
       <div>
         <q-btn
+          unelevated
+          square
+          no-caps
           label="Add Instance"
           type="submit"
           color="primary"
           :loading="isConnecting"
         />
-        <q-btn label="Reset" type="reset" color="primary" flat class="ml-2" />
+        <q-btn
+          flat
+          square
+          no-caps
+          label="Reset"
+          type="reset"
+          color="primary"
+          class="ml-2"
+        />
       </div>
     </q-form>
 
@@ -116,23 +134,25 @@
               size="sm"
               flat
               dense
-              round
+              square
               icon="key"
               class="text-text-muted"
+              aria-label="Copy API key"
               @click="copyKey(key)"
             >
-              <q-tooltip>Copy API Key</q-tooltip>
+              <q-tooltip>Copy API key</q-tooltip>
             </q-btn>
             <q-btn
               size="sm"
               flat
               dense
-              round
+              square
               icon="delete"
               color="negative"
+              aria-label="Delete instance"
               @click="deleteInstance(key)"
             >
-              <q-tooltip>Delete Instance</q-tooltip>
+              <q-tooltip>Delete instance</q-tooltip>
             </q-btn>
           </q-item-section>
         </q-item>

--- a/src/pages/SidebarSettings.vue
+++ b/src/pages/SidebarSettings.vue
@@ -2,7 +2,7 @@
   <div class="p-4 text-text">
     <!-- Header -->
     <div class="text-center font-bold border-b border-border pb-4 mb-4">
-      <div class="text-lg">Meilisearch Manager Settings</div>
+      <div class="mm-page-title text-lg">Meilisearch Manager Settings</div>
       <div class="text-sm font-normal text-text-muted mt-2">
         Version: {{ version || "N/A" }}
       </div>
@@ -106,7 +106,7 @@
     <!-- Instances List -->
     <q-card flat bordered>
       <q-card-section class="pb-0">
-        <div class="text-lg font-semibold text-text">Your Instances</div>
+        <div class="mm-section-title text-lg">Your Instances</div>
       </q-card-section>
 
       <q-list v-if="instances.length > 0" separator>

--- a/src/pages/SidebarSettings.vue
+++ b/src/pages/SidebarSettings.vue
@@ -1,14 +1,12 @@
 <template>
-  <div class="p-4">
+  <div class="p-4 text-text">
     <!-- Header -->
-    <div
-      class="text-center font-bold border-b border-gray-300 dark:border-gray-700 pb-4 mb-4 dark:text-white"
-    >
+    <div class="text-center font-bold border-b border-border pb-4 mb-4">
       <div class="text-lg">Meilisearch Manager Settings</div>
-      <div class="text-sm font-normal text-gray-600 dark:text-gray-400 mt-2">
+      <div class="text-sm font-normal text-text-muted mt-2">
         Version: {{ version || "N/A" }}
       </div>
-      <div class="text-sm font-normal text-gray-600 dark:text-gray-400">
+      <div class="text-sm font-normal text-text-muted">
         Instance:
         {{ activeInstance?.indexUrl ?? "none" }}
       </div>
@@ -66,7 +64,7 @@
         href="https://docs.meilisearch.com/reference/api/keys.html#actions"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-primary hover:underline text-sm dark:text-blue-400"
+        class="text-primary hover:underline text-sm"
       >
         <q-icon name="help_outline" size="xs" class="mr-1" />
         Permissions Documentation
@@ -74,17 +72,14 @@
     </div>
 
     <!-- Current Context Info -->
-    <div
-      v-if="currentIndex"
-      class="p-3 bg-gray-100 dark:bg-gray-800 rounded mb-4"
-    >
-      <div class="text-sm space-y-1 dark:text-gray-300">
+    <div v-if="currentIndex" class="p-3 bg-page border border-border mb-4">
+      <div class="text-sm space-y-1 text-text-muted">
         <div>
-          <span class="font-semibold">Current index:</span>
+          <span class="font-semibold text-text">Current index:</span>
           <span class="ml-2">{{ currentIndex ?? "" }}</span>
         </div>
         <div>
-          <span class="font-semibold">Current instance:</span>
+          <span class="font-semibold text-text">Current instance:</span>
           <span class="ml-2">{{ activeInstance?.label ?? "" }}</span>
         </div>
       </div>
@@ -93,7 +88,7 @@
     <!-- Instances List -->
     <q-card flat bordered>
       <q-card-section class="pb-0">
-        <div class="text-lg font-semibold dark:text-white">Your Instances</div>
+        <div class="text-lg font-semibold text-text">Your Instances</div>
       </q-card-section>
 
       <q-list v-if="instances.length > 0" separator>
@@ -102,16 +97,16 @@
           :key="key"
           clickable
           v-ripple
-          class="cursor-pointer dark:hover:bg-gray-800"
+          class="cursor-pointer hover:bg-page"
           :class="{
-            'bg-blue-50 dark:bg-blue-900': isActiveInstance(key),
+            'bg-page text-primary': isActiveInstance(key),
           }"
         >
           <q-item-section @click="selectInstance(key)">
-            <q-item-label class="font-semibold dark:text-white">
+            <q-item-label class="font-semibold text-text">
               {{ value?.label ?? "" }}
             </q-item-label>
-            <q-item-label caption class="dark:text-gray-400">
+            <q-item-label caption class="text-text-muted">
               {{ value?.indexUrl ?? "" }}
             </q-item-label>
           </q-item-section>
@@ -123,8 +118,8 @@
               dense
               round
               icon="key"
+              class="text-text-muted"
               @click="copyKey(key)"
-              class="dark:text-gray-300"
             >
               <q-tooltip>Copy API Key</q-tooltip>
             </q-btn>
@@ -145,14 +140,8 @@
 
       <!-- Empty state -->
       <div v-else class="text-center py-8">
-        <q-icon
-          name="cloud_off"
-          size="48px"
-          class="text-gray-400 dark:text-gray-600"
-        />
-        <p class="text-gray-600 dark:text-gray-400 mt-2 text-sm">
-          No instances configured yet
-        </p>
+        <q-icon name="cloud_off" size="48px" class="text-text-muted" />
+        <p class="text-text-muted mt-2 text-sm">No instances configured yet</p>
       </div>
     </q-card>
   </div>

--- a/src/pages/SimilarDocumentsPage.vue
+++ b/src/pages/SimilarDocumentsPage.vue
@@ -10,7 +10,7 @@
         />
         <div class="text-center">
           <div class="text-h6">Similar Documents</div>
-          <div class="text-caption text-grey-7">
+          <div class="text-caption text-text-muted">
             Source: <strong>{{ route.params.documentUid }}</strong>
           </div>
         </div>

--- a/src/pages/TasksPage.vue
+++ b/src/pages/TasksPage.vue
@@ -77,8 +77,10 @@
             label="Search"
             outlined
             dense
+            square
             class="flex-1 min-w-[200px]"
             clearable
+            placeholder="UID, type, index, or status"
           >
             <template #prepend>
               <q-icon name="search" />
@@ -187,9 +189,10 @@
                 <q-btn
                   flat
                   dense
-                  round
+                  square
                   size="sm"
                   icon="visibility"
+                  aria-label="View task details"
                   @click="toggleExpand(props)"
                 >
                   <q-tooltip>View details</q-tooltip>
@@ -201,10 +204,11 @@
                   "
                   flat
                   dense
-                  round
+                  square
                   size="sm"
                   icon="cancel"
                   color="negative"
+                  aria-label="Cancel task"
                   @click="cancelTask(props.row.uid)"
                 >
                   <q-tooltip>Cancel task</q-tooltip>

--- a/src/pages/TasksPage.vue
+++ b/src/pages/TasksPage.vue
@@ -1,16 +1,18 @@
 <template>
-  <q-page class="p-6">
+  <q-page class="p-6 bg-page">
     <!-- Header with filters and actions -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-bold">Tasks</h1>
-        <p class="text-sm text-gray-600">
+        <h1 class="text-2xl font-semibold text-text">Tasks</h1>
+        <p class="text-sm text-text-muted">
           Monitor and manage Meilisearch tasks
         </p>
       </div>
       <div class="flex gap-2">
         <q-btn
           outline
+          square
+          no-caps
           color="primary"
           icon="refresh"
           label="Refresh"
@@ -20,6 +22,8 @@
         <q-btn
           v-if="selectedTasks.length > 0"
           outline
+          square
+          no-caps
           color="negative"
           icon="cancel"
           :label="`Cancel ${selectedTasks.length} task${selectedTasks.length > 1 ? 's' : ''}`"
@@ -30,42 +34,42 @@
 
     <!-- Stats cards -->
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-blue-500">
+          <div class="text-3xl font-bold text-primary">
             {{ taskStats.total }}
           </div>
-          <div class="text-sm text-gray-600">Total Tasks</div>
+          <div class="text-sm text-text-muted">Total tasks</div>
         </q-card-section>
       </q-card>
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-green-500">
+          <div class="text-3xl font-bold text-secondary">
             {{ taskStats.succeeded }}
           </div>
-          <div class="text-sm text-gray-600">Succeeded</div>
+          <div class="text-sm text-text-muted">Succeeded</div>
         </q-card-section>
       </q-card>
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-orange-500">
+          <div class="text-3xl font-bold text-warning">
             {{ taskStats.processing }}
           </div>
-          <div class="text-sm text-gray-600">Processing</div>
+          <div class="text-sm text-text-muted">Processing</div>
         </q-card-section>
       </q-card>
-      <q-card flat bordered>
+      <q-card flat bordered square class="bg-page-elevated">
         <q-card-section class="text-center">
-          <div class="text-3xl font-bold text-red-500">
+          <div class="text-3xl font-bold text-negative">
             {{ taskStats.failed }}
           </div>
-          <div class="text-sm text-gray-600">Failed</div>
+          <div class="text-sm text-text-muted">Failed</div>
         </q-card-section>
       </q-card>
     </div>
 
     <!-- Filters -->
-    <q-card flat bordered class="mb-4">
+    <q-card flat bordered square class="bg-page-elevated mb-4">
       <q-card-section>
         <div class="flex flex-wrap gap-4 items-end">
           <q-input

--- a/src/pages/TasksPage.vue
+++ b/src/pages/TasksPage.vue
@@ -178,7 +178,7 @@
               }}</span>
             </q-td>
             <q-td key="enqueuedAt" :props="props">
-              <div class="text-xs text-gray-600">
+              <div class="text-xs text-text-muted">
                 {{ formatDate(props.row.enqueuedAt) }}
               </div>
             </q-td>
@@ -214,7 +214,7 @@
           </q-tr>
           <q-tr v-if="props.expand" :props="props">
             <q-td colspan="100%">
-              <div class="p-4 bg-gray-50 dark:bg-gray-800">
+              <div class="p-4 bg-page">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <!-- Task details -->
                   <div>
@@ -225,7 +225,7 @@
                         :key="item.label"
                         class="flex justify-between"
                       >
-                        <span class="text-gray-600 dark:text-gray-400">{{
+                        <span class="text-text-muted">{{
                           item.label
                         }}</span>
                         <component
@@ -247,7 +247,7 @@
                         :key="item.label"
                         class="flex justify-between"
                       >
-                        <span class="text-gray-600 dark:text-gray-400">{{
+                        <span class="text-text-muted">{{
                           item.label
                         }}</span>
                         <span>{{ item.value }}</span>
@@ -257,8 +257,8 @@
 
                   <!-- Error details if present -->
                   <div v-if="props.row.error" class="md:col-span-2">
-                    <div class="text-subtitle2 mb-2 text-red-600">Error</div>
-                    <q-banner dense class="bg-red-100 text-red-900">
+                    <div class="text-subtitle2 mb-2 text-negative">Error</div>
+                    <q-banner dense class="bg-negative text-on-primary">
                       <div class="space-y-1 text-sm">
                         <div>
                           <strong>Code:</strong> {{ props.row.error.code }}
@@ -275,7 +275,7 @@
                           <a
                             :href="props.row.error.link"
                             target="_blank"
-                            class="text-blue-600 underline"
+                            class="underline text-on-primary"
                             >{{ props.row.error.link }}</a
                           >
                         </div>
@@ -289,7 +289,7 @@
                     <q-card
                       flat
                       bordered
-                      class="bg-gray-900 dark:bg-gray-950 text-white"
+                      class="bg-page text-text"
                     >
                       <q-card-section>
                         <pre class="text-xs overflow-auto">{{
@@ -307,8 +307,8 @@
         <template v-slot:no-data>
           <div class="text-center p-8">
             <q-icon name="info" size="xl" color="grey-5" class="mb-4" />
-            <div class="text-h6 text-grey-7">No tasks found</div>
-            <div class="text-caption text-grey-6">
+            <div class="text-h6 text-text-muted">No tasks found</div>
+            <div class="text-caption text-text-muted">
               Tasks will appear here once operations are performed
             </div>
           </div>

--- a/src/pages/TasksPage.vue
+++ b/src/pages/TasksPage.vue
@@ -3,7 +3,7 @@
     <!-- Header with filters and actions -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-text">Tasks</h1>
+        <h1 class="mm-page-title text-2xl">Tasks</h1>
         <p class="text-sm text-text-muted">
           Monitor and manage Meilisearch tasks
         </p>
@@ -222,7 +222,9 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <!-- Task details -->
                   <div>
-                    <div class="text-subtitle2 mb-2">Task Details</div>
+                    <div class="mm-section-title text-subtitle2 mb-2">
+                      Task Details
+                    </div>
                     <div class="space-y-2 text-sm">
                       <div
                         v-for="item in getTaskDetails(props.row)"
@@ -244,7 +246,9 @@
 
                   <!-- Timestamps -->
                   <div>
-                    <div class="text-subtitle2 mb-2">Timeline</div>
+                    <div class="mm-section-title text-subtitle2 mb-2">
+                      Timeline
+                    </div>
                     <div class="space-y-2 text-sm">
                       <div
                         v-for="item in getTimeline(props.row)"
@@ -289,7 +293,9 @@
 
                   <!-- Details object -->
                   <div class="md:col-span-2">
-                    <div class="text-subtitle2 mb-2">Additional Details</div>
+                    <div class="mm-section-title text-subtitle2 mb-2">
+                      Additional Details
+                    </div>
                     <q-card
                       flat
                       bordered

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,13 +1,11 @@
 import IndexPageVue from "pages/IndexPage.vue";
-import SidebarSettingsVue from "pages/SidebarSettings.vue";
+import InstancesPageVue from "pages/InstancesPage.vue";
 import TasksPageVue from "src/pages/TasksPage.vue";
 import IndexDetailPage from "src/pages/IndexDetailPage.vue";
 import KeysPageVue from "src/pages/KeysPage.vue";
 import DocumentDetailPage from "src/pages/DocumentDetailPage.vue";
 import SimilarDocumentsPage from "src/pages/SimilarDocumentsPage.vue";
 import DynamicRulesPage from "src/pages/DynamicRulesPage.vue";
-import PreviewPageVue from "src/pages/PreviewPage.vue";
-import PreviewSidebarVue from "src/pages/PreviewSidebar.vue";
 
 const routes = [
   {
@@ -16,74 +14,42 @@ const routes = [
     children: [
       {
         path: "",
-        components: {
-          main: IndexPageVue,
-          side: SidebarSettingsVue,
-        },
+        component: IndexPageVue,
       },
       {
-        path: "/tasks",
-        components: {
-          main: TasksPageVue,
-          side: SidebarSettingsVue,
-        },
+        path: "instances",
+        component: InstancesPageVue,
       },
       {
-        path: "/keys",
-        components: {
-          main: KeysPageVue,
-          side: SidebarSettingsVue,
-        },
+        path: "tasks",
+        component: TasksPageVue,
       },
       {
-        path: "/dynamic-rules",
-        components: {
-          main: DynamicRulesPage,
-          side: SidebarSettingsVue,
-        },
+        path: "keys",
+        component: KeysPageVue,
       },
       {
-        path: "/index-details/:uid",
-        components: {
-          main: IndexDetailPage,
-          side: SidebarSettingsVue,
-        },
-        props: ["uid"],
+        path: "dynamic-rules",
+        component: DynamicRulesPage,
       },
       {
-        path: "/documents/:indexUid/:documentUid",
-        components: {
-          main: DocumentDetailPage,
-          side: SidebarSettingsVue,
-        },
-        props: ["indexUid", "documentUid"],
+        path: "index-details/:uid",
+        component: IndexDetailPage,
+        props: true,
       },
       {
-        path: "/similar/:indexUid/:documentUid",
-        components: {
-          main: SimilarDocumentsPage,
-          side: SidebarSettingsVue,
-        },
-        props: ["indexUid", "documentUid"],
+        path: "documents/:indexUid/:documentUid",
+        component: DocumentDetailPage,
+        props: true,
+      },
+      {
+        path: "similar/:indexUid/:documentUid",
+        component: SimilarDocumentsPage,
+        props: true,
       },
     ],
   },
   // Preview mode disabled (alpha feature)
-  // {
-  //   path: "/",
-  //   component: () => import("layouts/PreviewLayout.vue"),
-  //   children: [
-  //     {
-  //       path: "/preview",
-  //       components: {
-  //         main: PreviewPageVue,
-  //         side: PreviewSidebarVue,
-  //       },
-  //     },
-  //   ],
-  // },
-  // Always leave this as last one,
-  // but you can also remove it
   {
     path: "/:catchAll(.*)*",
     component: () => import("pages/ErrorNotFound.vue"),

--- a/src/themes/applyTheme.js
+++ b/src/themes/applyTheme.js
@@ -1,0 +1,67 @@
+import { Dark, setCssVar } from "quasar";
+import {
+  DEFAULT_THEME_ID,
+  QUASAR_BRAND_KEYS,
+  TOKEN_KEYS,
+  resolveTheme,
+  themes,
+  tokenToCssVar,
+} from "./catalog.js";
+
+export const THEME_STORAGE_KEY = "meili-manager-theme";
+export { DEFAULT_THEME_ID };
+
+/**
+ * Resolve a stored theme id, including legacy darkMode from Pinia settings.
+ */
+export function readStoredThemeId() {
+  try {
+    const direct = localStorage.getItem(THEME_STORAGE_KEY);
+    if (direct && themes[direct]) return direct;
+
+    const raw = localStorage.getItem("settings");
+    if (raw) {
+      const data = JSON.parse(raw);
+      if (data?.themeId && themes[data.themeId]) return data.themeId;
+      if (data?.darkMode === false) return "weeumson-light";
+    }
+  } catch {
+    // ignore corrupt storage
+  }
+  return DEFAULT_THEME_ID;
+}
+
+/**
+ * Apply a catalog theme: CSS vars, data-theme, Quasar Dark + brand.
+ */
+export function applyTheme(id) {
+  const theme = resolveTheme(id);
+  const root = document.documentElement;
+
+  root.dataset.theme = theme.id;
+  root.style.colorScheme = theme.isDark ? "dark" : "light";
+
+  for (const key of TOKEN_KEYS) {
+    const value = theme.tokens[key];
+    if (value) {
+      root.style.setProperty(tokenToCssVar(key), value);
+    }
+  }
+
+  Dark.set(theme.isDark);
+
+  for (const key of QUASAR_BRAND_KEYS) {
+    const value = theme.tokens[key];
+    if (value) setCssVar(key, value);
+  }
+  setCssVar("dark", theme.tokens.pageElevated);
+  setCssVar("dark-page", theme.tokens.page);
+
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme.id);
+  } catch {
+    // private mode / quota
+  }
+
+  return theme;
+}

--- a/src/themes/applyTheme.js
+++ b/src/themes/applyTheme.js
@@ -54,6 +54,11 @@ export function applyTheme(id) {
     const value = theme.tokens[key];
     if (value) setCssVar(key, value);
   }
+  // Ink on filled primary surfaces (Send, unelevated primary). Not a Quasar
+  // brand key; consumed by app.scss and Tailwind text-on-primary.
+  if (theme.tokens.onPrimary) {
+    setCssVar("on-primary", theme.tokens.onPrimary);
+  }
   setCssVar("dark", theme.tokens.pageElevated);
   setCssVar("dark-page", theme.tokens.page);
 

--- a/src/themes/catalog.js
+++ b/src/themes/catalog.js
@@ -33,6 +33,16 @@ export const QUASAR_BRAND_KEYS = [
   "warning",
 ];
 
+/**
+ * Theme picker swatch order (catalog tokens only):
+ * page → pageElevated → primary → text
+ */
+export const SWATCH_TOKEN_KEYS = ["page", "pageElevated", "primary", "text"];
+
+export function getThemeSwatches(theme) {
+  return SWATCH_TOKEN_KEYS.map((key) => theme.tokens[key]);
+}
+
 export const themes = {
   "weeumson-dark": {
     id: "weeumson-dark",
@@ -44,7 +54,8 @@ export const themes = {
       pageElevated: "#232019",
       border: "#7a7268",
       text: "#ebe6dc",
-      textMuted: "#b8b0a4",
+      // Light enough for field labels on elevated cards (AA + readable taupe).
+      textMuted: "#d4cbc0",
       primary: "#b85538",
       secondary: "#8a9480",
       accent: "#b8956c",

--- a/src/themes/catalog.js
+++ b/src/themes/catalog.js
@@ -1,0 +1,157 @@
+/**
+ * Single source of truth for meili-manager themes.
+ * Picker swatches, CSS vars, Quasar brand, and contrast checks all read from here.
+ */
+
+export const DEFAULT_THEME_ID = "weeumson-dark";
+
+export const TOKEN_KEYS = [
+  "page",
+  "pageElevated",
+  "border",
+  "text",
+  "textMuted",
+  "primary",
+  "secondary",
+  "accent",
+  "focusRing",
+  "onPrimary",
+  "positive",
+  "negative",
+  "info",
+  "warning",
+];
+
+/** Quasar setCssVar brand keys derived from the same tokens object. */
+export const QUASAR_BRAND_KEYS = [
+  "primary",
+  "secondary",
+  "accent",
+  "positive",
+  "negative",
+  "info",
+  "warning",
+];
+
+export const themes = {
+  "weeumson-dark": {
+    id: "weeumson-dark",
+    label: "Weeumson Dark",
+    description: "Earthy dark shell with terracotta primary.",
+    isDark: true,
+    tokens: {
+      page: "#1a1714",
+      pageElevated: "#232019",
+      border: "#7a7268",
+      text: "#ebe6dc",
+      textMuted: "#b8b0a4",
+      primary: "#b85538",
+      secondary: "#8a9480",
+      accent: "#b8956c",
+      focusRing: "#d4a574",
+      onPrimary: "#ffffff",
+      positive: "#7a9a70",
+      negative: "#d46a5c",
+      info: "#7a9eb0",
+      warning: "#d4a05a",
+    },
+  },
+  "weeumson-light": {
+    id: "weeumson-light",
+    label: "Weeumson Light",
+    description: "Warm paper surfaces with the same terracotta brand.",
+    isDark: false,
+    tokens: {
+      page: "#f7f3ec",
+      pageElevated: "#fffdf8",
+      border: "#8a8278",
+      text: "#1c1916",
+      textMuted: "#5a544c",
+      primary: "#a34a30",
+      secondary: "#5a6554",
+      accent: "#8a6e4a",
+      focusRing: "#a34a30",
+      onPrimary: "#ffffff",
+      positive: "#3d6b38",
+      negative: "#a84335",
+      info: "#3d6a80",
+      warning: "#8a5a18",
+    },
+  },
+  "slate-dark": {
+    id: "slate-dark",
+    label: "Slate Dark",
+    description: "Cool slate chrome with blue-teal primary.",
+    isDark: true,
+    tokens: {
+      page: "#121418",
+      pageElevated: "#1a1d24",
+      border: "#6b7280",
+      text: "#e8eaed",
+      textMuted: "#a8adb6",
+      primary: "#2dd4bf",
+      secondary: "#94a3b8",
+      accent: "#67e8f9",
+      focusRing: "#5eead4",
+      onPrimary: "#042f2e",
+      positive: "#4ade80",
+      negative: "#f87171",
+      info: "#7dd3fc",
+      warning: "#fbbf24",
+    },
+  },
+  "slate-light": {
+    id: "slate-light",
+    label: "Slate Light",
+    description: "Clean light admin chrome in the slate family.",
+    isDark: false,
+    tokens: {
+      page: "#f4f6f8",
+      pageElevated: "#ffffff",
+      border: "#6b7280",
+      text: "#111827",
+      textMuted: "#4b5563",
+      primary: "#0f766e",
+      secondary: "#475569",
+      accent: "#0e7490",
+      focusRing: "#0d9488",
+      onPrimary: "#ffffff",
+      positive: "#166534",
+      negative: "#b91c1c",
+      info: "#0369a1",
+      warning: "#8a5a18",
+    },
+  },
+  "high-contrast": {
+    id: "high-contrast",
+    label: "High Contrast",
+    description: "Near black and white with strong borders and focus.",
+    isDark: true,
+    tokens: {
+      page: "#000000",
+      pageElevated: "#0a0a0a",
+      border: "#ffffff",
+      text: "#ffffff",
+      textMuted: "#e6e6e6",
+      primary: "#ffe600",
+      secondary: "#ffffff",
+      accent: "#00e5ff",
+      focusRing: "#00e5ff",
+      onPrimary: "#000000",
+      positive: "#00ff66",
+      negative: "#ff4d4d",
+      info: "#00e5ff",
+      warning: "#ffe600",
+    },
+  },
+};
+
+export function resolveTheme(id) {
+  return themes[id] || themes[DEFAULT_THEME_ID];
+}
+
+/** pageElevated → --color-page-elevated */
+export function tokenToCssVar(key) {
+  const kebab = key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+  return `--color-${kebab}`;
+}

--- a/src/themes/catalog.js
+++ b/src/themes/catalog.js
@@ -128,11 +128,12 @@ export const themes = {
     description: "Near black and white with strong borders and focus.",
     isDark: true,
     tokens: {
+      // Primary is bright yellow; onPrimary must stay near-black (not white).
       page: "#000000",
       pageElevated: "#0a0a0a",
       border: "#ffffff",
       text: "#ffffff",
-      textMuted: "#e6e6e6",
+      textMuted: "#f0f0f0",
       primary: "#ffe600",
       secondary: "#ffffff",
       accent: "#00e5ff",

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,30 @@
+import { copyToClipboard } from "quasar";
+import { showError, showSuccess } from "src/utils/notifications";
+
+/**
+ * Copy text to the clipboard and show a Quasar Notify result.
+ * @param {string} text
+ * @param {{ successMessage?: string; emptyMessage?: string }} [opts]
+ * @returns {Promise<boolean>} true when something was copied
+ */
+export async function copyText(text, opts = {}) {
+  const {
+    successMessage = "Copied to clipboard",
+    emptyMessage = "Nothing to copy",
+  } = opts;
+
+  const value = text == null ? "" : String(text);
+  if (!value.trim()) {
+    showError(emptyMessage);
+    return false;
+  }
+
+  try {
+    await copyToClipboard(value);
+    showSuccess(successMessage);
+    return true;
+  } catch {
+    showError("Failed to copy to clipboard");
+    return false;
+  }
+}

--- a/tests/e2e/shell-screenshots.spec.js
+++ b/tests/e2e/shell-screenshots.spec.js
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const screenshotDir = path.join(__dirname, 'screenshots')
+
+/**
+ * Smoke visual review for agents: captures connect/shell UI without Meili credentials.
+ * Tag @visual so `npm run review:screenshots` can target this suite.
+ */
+test.describe('shell screenshots @visual', () => {
+  test.beforeEach(async ({ page }) => {
+    // Fresh browser context has empty localStorage (no saved instances / keys).
+    await page.goto('/#/')
+    await expect(page.getByLabel('Toggle navigation')).toBeVisible({
+      timeout: 30_000,
+    })
+    await expect(
+      page.getByRole('link', { name: /Meili(?:search)? Manager/ }),
+    ).toBeVisible()
+  })
+
+  test('home shell (unconnected)', async ({ page }, testInfo) => {
+    const project = testInfo.project.name
+    await expect(page.getByText('Connect to Meilisearch')).toBeVisible()
+
+    if (project === 'mobile') {
+      // home-mobile must be drawer-closed; home-drawer-mobile is the open shot.
+      // Drawer nav stays in the DOM when closed; use the mobile backdrop instead.
+      const backdrop = page.locator('.q-drawer__backdrop')
+      if (await backdrop.isVisible()) {
+        await page.getByLabel('Toggle navigation').click()
+        await expect(backdrop).toBeHidden()
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(screenshotDir, `home-${project}.png`),
+      fullPage: true,
+    })
+
+    if (project === 'mobile') {
+      const backdrop = page.locator('.q-drawer__backdrop')
+      await page.getByLabel('Toggle navigation').click()
+      await expect(backdrop).toBeVisible()
+      await page.screenshot({
+        path: path.join(screenshotDir, `home-drawer-${project}.png`),
+        fullPage: true,
+      })
+    }
+  })
+
+  test('instances page (unconnected)', async ({ page }, testInfo) => {
+    const project = testInfo.project.name
+    await page.goto('/#/instances')
+    await expect(page.getByLabel('Toggle navigation')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Instances' })).toBeVisible()
+
+    await page.screenshot({
+      path: path.join(screenshotDir, `instances-${project}.png`),
+      fullPage: true,
+    })
+  })
+})

--- a/tests/e2e/theme-screenshots.spec.js
+++ b/tests/e2e/theme-screenshots.spec.js
@@ -1,64 +1,69 @@
-import { test, expect } from '@playwright/test'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const screenshotDir = path.join(__dirname, 'screenshots')
-
-const HOME_THEMES = ['weeumson-dark', 'weeumson-light', 'slate-light']
-
-/**
- * Desktop theme catalog shots for visual QA.
- * Sets localStorage before navigation so Pinia + boot theme agree.
- */
-test.describe('theme catalog screenshots @visual', () => {
-  for (const themeId of HOME_THEMES) {
-    test(`home desktop (${themeId})`, async ({ page }, testInfo) => {
-      test.skip(testInfo.project.name !== 'desktop', 'desktop-only theme review')
-
-      await page.addInitScript((id) => {
-        localStorage.setItem('meili-manager-theme', id)
-        localStorage.setItem('settings', JSON.stringify({ themeId: id }))
-      }, themeId)
-
-      await page.goto('/#/')
-      await expect(page.getByLabel('Toggle navigation')).toBeVisible({
-        timeout: 30_000,
-      })
-      await expect(page.locator('html')).toHaveAttribute('data-theme', themeId)
-      await expect(page.getByText('Connect to Meilisearch')).toBeVisible()
-
-      await page.screenshot({
-        path: path.join(screenshotDir, `theme-home-${themeId}-desktop.png`),
-        fullPage: true,
-      })
-    })
-  }
-
-  test('theme picker open (desktop)', async ({ page }, testInfo) => {
-    test.skip(testInfo.project.name !== 'desktop', 'desktop-only theme review')
-
-    await page.addInitScript(() => {
-      localStorage.setItem('meili-manager-theme', 'weeumson-dark')
-      localStorage.setItem(
-        'settings',
-        JSON.stringify({ themeId: 'weeumson-dark' }),
-      )
-    })
-
-    await page.goto('/#/')
-    await expect(page.getByLabel('Toggle navigation')).toBeVisible({
-      timeout: 30_000,
-    })
-
-    await page.getByLabel('Theme').click()
-    await expect(page.getByText('Weeumson Dark')).toBeVisible()
-    await expect(page.getByText('Weeumson Light')).toBeVisible()
-    await expect(page.getByText('Slate Light')).toBeVisible()
-
-    await page.screenshot({
-      path: path.join(screenshotDir, 'theme-picker-open-desktop.png'),
-      fullPage: true,
-    })
-  })
-})
+import { test, expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const screenshotDir = path.join(__dirname, 'screenshots')
+
+const HOME_THEMES = [
+  'weeumson-dark',
+  'weeumson-light',
+  'slate-light',
+  'high-contrast',
+]
+
+/**
+ * Desktop theme catalog shots for visual QA.
+ * Sets localStorage before navigation so Pinia + boot theme agree.
+ */
+test.describe('theme catalog screenshots @visual', () => {
+  for (const themeId of HOME_THEMES) {
+    test(`home desktop (${themeId})`, async ({ page }, testInfo) => {
+      test.skip(testInfo.project.name !== 'desktop', 'desktop-only theme review')
+
+      await page.addInitScript((id) => {
+        localStorage.setItem('meili-manager-theme', id)
+        localStorage.setItem('settings', JSON.stringify({ themeId: id }))
+      }, themeId)
+
+      await page.goto('/#/')
+      await expect(page.getByLabel('Toggle navigation')).toBeVisible({
+        timeout: 30_000,
+      })
+      await expect(page.locator('html')).toHaveAttribute('data-theme', themeId)
+      await expect(page.getByText('Connect to Meilisearch')).toBeVisible()
+
+      await page.screenshot({
+        path: path.join(screenshotDir, `theme-home-${themeId}-desktop.png`),
+        fullPage: true,
+      })
+    })
+  }
+
+  test('theme picker open (desktop)', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-only theme review')
+
+    await page.addInitScript(() => {
+      localStorage.setItem('meili-manager-theme', 'weeumson-dark')
+      localStorage.setItem(
+        'settings',
+        JSON.stringify({ themeId: 'weeumson-dark' }),
+      )
+    })
+
+    await page.goto('/#/')
+    await expect(page.getByLabel('Toggle navigation')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    await page.getByLabel('Theme').click()
+    await expect(page.getByText('Weeumson Dark')).toBeVisible()
+    await expect(page.getByText('Weeumson Light')).toBeVisible()
+    await expect(page.getByText('Slate Light')).toBeVisible()
+
+    await page.screenshot({
+      path: path.join(screenshotDir, 'theme-picker-open-desktop.png'),
+      fullPage: true,
+    })
+  })
+})

--- a/tests/e2e/theme-screenshots.spec.js
+++ b/tests/e2e/theme-screenshots.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const screenshotDir = path.join(__dirname, 'screenshots')
+
+const HOME_THEMES = ['weeumson-dark', 'weeumson-light', 'slate-light']
+
+/**
+ * Desktop theme catalog shots for visual QA.
+ * Sets localStorage before navigation so Pinia + boot theme agree.
+ */
+test.describe('theme catalog screenshots @visual', () => {
+  for (const themeId of HOME_THEMES) {
+    test(`home desktop (${themeId})`, async ({ page }, testInfo) => {
+      test.skip(testInfo.project.name !== 'desktop', 'desktop-only theme review')
+
+      await page.addInitScript((id) => {
+        localStorage.setItem('meili-manager-theme', id)
+        localStorage.setItem('settings', JSON.stringify({ themeId: id }))
+      }, themeId)
+
+      await page.goto('/#/')
+      await expect(page.getByLabel('Toggle navigation')).toBeVisible({
+        timeout: 30_000,
+      })
+      await expect(page.locator('html')).toHaveAttribute('data-theme', themeId)
+      await expect(page.getByText('Connect to Meilisearch')).toBeVisible()
+
+      await page.screenshot({
+        path: path.join(screenshotDir, `theme-home-${themeId}-desktop.png`),
+        fullPage: true,
+      })
+    })
+  }
+
+  test('theme picker open (desktop)', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'desktop-only theme review')
+
+    await page.addInitScript(() => {
+      localStorage.setItem('meili-manager-theme', 'weeumson-dark')
+      localStorage.setItem(
+        'settings',
+        JSON.stringify({ themeId: 'weeumson-dark' }),
+      )
+    })
+
+    await page.goto('/#/')
+    await expect(page.getByLabel('Toggle navigation')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    await page.getByLabel('Theme').click()
+    await expect(page.getByText('Weeumson Dark')).toBeVisible()
+    await expect(page.getByText('Weeumson Light')).toBeVisible()
+    await expect(page.getByText('Slate Light')).toBeVisible()
+
+    await page.screenshot({
+      path: path.join(screenshotDir, 'theme-picker-open-desktop.png'),
+      fullPage: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Ships **2.1.0**: Weeumson-style UX overhaul with index-first workspace navigation and a dedicated Search Playground (presets, hybrid search, n8n/clipboard export).
- Adds a **theme catalog** with WCAG AA presets, picker (four swatches), high-contrast mode, Playwright shell screenshots, and theme docs; MIT LICENSE.
- Hardens contrast and hybrid search: sticky footer readability, banner/JSON editor dark fixes, Overview chips, full-contrast headings, required embedder always sent, LLM demo presets apply hybrid state.
- Polish and fixes: sticky Weeumson attribution footer, control tooltips/aria-labels, Documents filter clear crash, env ignore / src-bex quarantine.

## Test plan
- [ ] Open app on Overview and confirm index-first nav and sticky footer attribution
- [ ] Cycle theme presets (including high-contrast) and spot-check chips, banners, headings, and primary buttons
- [ ] Use Playground: hybrid search with embedder, LLM demo presets, n8n export paste into canvas
- [ ] Smoke Documents filter attribute search clear (no crash)
- [ ] Confirm LICENSE and version 2.1.0 in package metadata
