### PR TITLE
Add Umami analytics and use main for deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Umami analytics (optional; both required to load the tracker). Client-only via src/boot/umami.js.
+# n8n-01 Umami uses TRACKER_SCRIPT_NAME=stats, so the path is /stats (not /script.js).
+# Production website ID for meili-manager.weeumson.com is documented in docs/umami.md (set in DO build env).
+VITE_UMAMI_URL=https://analytics.weeumson.com/stats
+VITE_UMAMI_WEBSITE_ID=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
         run: npm run build-changelog
 
       - name: Build application 🔧
+        env:
+          VITE_UMAMI_URL: ${{ vars.VITE_UMAMI_URL }}
+          VITE_UMAMI_WEBSITE_ID: ${{ vars.VITE_UMAMI_WEBSITE_ID }}
         run: npm run build
 
       - name: Move changelog to dist 📋

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 # Local env (never commit secrets)
 .env
 .env.*
+!.env.example
 
 # Quasar core related directories
 .quasar

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Credentials never leave the browser: instance URLs and API keys are stored in `l
 - Dual-version QA checklist: [`docs/qa-checklist-1.11-1.42.md`](docs/qa-checklist-1.11-1.42.md)
 - GitHub release draft: [`RELEASE_DRAFT_1.42.md`](RELEASE_DRAFT_1.42.md)
 - Playwright shell screenshots (mobile/desktop review): [`docs/e2e-screenshots.md`](docs/e2e-screenshots.md)
+- Umami analytics (optional DO build env): [`docs/umami.md`](docs/umami.md)
 
 ## Quick start
 
@@ -168,6 +169,17 @@ Document list field resolution lives in `src/meili-core/utils/display-settings.j
 - Output directory: `dist/spa`
 
 Host on any static file server (Nginx, Caddy, GitHub Pages, DigitalOcean Static Site, etc.). Hash routes avoid server rewrite requirements.
+
+### Umami (optional)
+
+Client analytics load only when both `VITE_UMAMI_URL` and `VITE_UMAMI_WEBSITE_ID` are set at build time (`src/boot/umami.js`). See [`.env.example`](.env.example) and [`docs/umami.md`](docs/umami.md).
+
+For DigitalOcean builds of **meili-manager.weeumson.com**, set:
+
+- `VITE_UMAMI_URL` = `https://analytics.weeumson.com/stats`
+- `VITE_UMAMI_WEBSITE_ID` = `7d58f62f-6f41-45f2-92be-406714151bbe`
+
+Register the domain in Umami admin as `meili-manager.weeumson.com`.
 
 ### Native applications
 

--- a/README.md
+++ b/README.md
@@ -174,12 +174,14 @@ Host on any static file server (Nginx, Caddy, GitHub Pages, DigitalOcean Static 
 
 Client analytics load only when both `VITE_UMAMI_URL` and `VITE_UMAMI_WEBSITE_ID` are set at build time (`src/boot/umami.js`). See [`.env.example`](.env.example) and [`docs/umami.md`](docs/umami.md).
 
-For DigitalOcean builds of **meili-manager.weeumson.com**, set:
+For GitHub Actions builds (`.github/workflows/deploy.yml` → `deploy-branch`), set **repository variables** (not secrets):
 
 - `VITE_UMAMI_URL` = `https://analytics.weeumson.com/stats`
 - `VITE_UMAMI_WEBSITE_ID` = `7d58f62f-6f41-45f2-92be-406714151bbe`
 
-Register the domain in Umami admin as `meili-manager.weeumson.com`.
+Path: **Settings → Secrets and variables → Actions → Variables**.
+
+The same keys work for DigitalOcean Static Site build env. Register the domain in Umami admin as `meili-manager.weeumson.com`.
 
 ### Native applications
 

--- a/docs/umami.md
+++ b/docs/umami.md
@@ -1,0 +1,23 @@
+# Umami analytics
+
+Optional client-only pageview tracking via [`src/boot/umami.js`](../src/boot/umami.js). The boot file is a no-op unless both build-time env vars are set. Offline browsers skip inject. Hash-mode SPA navigations are recorded with `router.afterEach` (first load is handled by the Umami script).
+
+## Env vars
+
+| Variable | Purpose |
+|----------|---------|
+| `VITE_UMAMI_URL` | Tracker script URL (n8n-01 uses `TRACKER_SCRIPT_NAME=stats`, so path is `/stats`) |
+| `VITE_UMAMI_WEBSITE_ID` | Website ID from Umami admin |
+
+Copy from [`.env.example`](../.env.example) for local builds. Leave `VITE_UMAMI_WEBSITE_ID` empty locally if you do not want analytics in dev.
+
+## Production (DigitalOcean)
+
+For **meili-manager.weeumson.com**, set these as **build-time** environment variables on the DO Static Site / App:
+
+- `VITE_UMAMI_URL` = `https://analytics.weeumson.com/stats`
+- `VITE_UMAMI_WEBSITE_ID` = `7d58f62f-6f41-45f2-92be-406714151bbe`
+
+In Umami admin, the website domain should be registered as `meili-manager.weeumson.com`.
+
+Redeploy after changing build env so Vite bakes the values into the client bundle.

--- a/docs/umami.md
+++ b/docs/umami.md
@@ -11,13 +11,21 @@ Optional client-only pageview tracking via [`src/boot/umami.js`](../src/boot/uma
 
 Copy from [`.env.example`](../.env.example) for local builds. Leave `VITE_UMAMI_WEBSITE_ID` empty locally if you do not want analytics in dev.
 
+## Production (GitHub Actions → `deploy-branch`)
+
+CI builds via [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) and publishes to `deploy-branch`. Vite reads Umami values from **repository variables** (Settings → Secrets and variables → Actions → Variables):
+
+| Repository variable | Value |
+|---------------------|-------|
+| `VITE_UMAMI_URL` | `https://analytics.weeumson.com/stats` |
+| `VITE_UMAMI_WEBSITE_ID` | `7d58f62f-6f41-45f2-92be-406714151bbe` |
+
+UI path: **Settings → Secrets and variables → Actions → Variables** (or `https://github.com/<owner>/meili-manager/settings/variables/actions`).
+
+After setting or changing variables, re-run the deploy workflow (or push to `main`) so Vite bakes them into the client bundle.
+
 ## Production (DigitalOcean)
 
-For **meili-manager.weeumson.com**, set these as **build-time** environment variables on the DO Static Site / App:
-
-- `VITE_UMAMI_URL` = `https://analytics.weeumson.com/stats`
-- `VITE_UMAMI_WEBSITE_ID` = `7d58f62f-6f41-45f2-92be-406714151bbe`
+If you also build on DigitalOcean for **meili-manager.weeumson.com**, set the same keys as **build-time** environment variables on the Static Site / App.
 
 In Umami admin, the website domain should be registered as `meili-manager.weeumson.com`.
-
-Redeploy after changing build env so Vite bakes the values into the client bundle.

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -27,7 +27,7 @@ export default configure(function (/* ctx */) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli/boot-files
-    boot: ["theme", "instant-search"],
+    boot: ["theme", "umami", "instant-search"],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ["tailwind.css", "app.scss"],

--- a/src/boot/umami.js
+++ b/src/boot/umami.js
@@ -1,0 +1,45 @@
+/**
+ * Client-only Umami tracker. No-op when env is missing or the browser is offline.
+ * Set VITE_UMAMI_URL (e.g. https://analytics.weeumson.com/stats) and
+ * VITE_UMAMI_WEBSITE_ID (from Umami admin for meili-manager.weeumson.com).
+ * Hash-mode SPA: pass router so afterEach records client navigations.
+ */
+import { boot } from "quasar/wrappers";
+
+export default boot(({ router }) => {
+  if (typeof window === "undefined") return;
+
+  const src = String(import.meta.env.VITE_UMAMI_URL || "").trim();
+  const websiteId = String(import.meta.env.VITE_UMAMI_WEBSITE_ID || "").trim();
+  if (!src || !websiteId) return;
+  if (navigator.onLine === false) return;
+
+  const alreadyInjected = [...document.querySelectorAll("script[data-website-id]")].some(
+    (node) => node.getAttribute("data-website-id") === websiteId,
+  );
+  if (!alreadyInjected) {
+    const script = document.createElement("script");
+    script.defer = true;
+    script.src = src;
+    script.dataset.websiteId = websiteId;
+    document.head.appendChild(script);
+  }
+
+  if (!router || typeof router.afterEach !== "function") return;
+
+  // Initial pageview is recorded by the script; track SPA/hash navigations after that.
+  let isFirstNavigation = true;
+  router.afterEach((to) => {
+    if (isFirstNavigation) {
+      isFirstNavigation = false;
+      return;
+    }
+    if (navigator.onLine === false) return;
+    if (typeof window.umami?.track !== "function") return;
+    window.umami.track((props) => ({
+      ...props,
+      url: to.fullPath,
+      title: typeof document !== "undefined" ? document.title : props.title,
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- Add Optional Umami analytics boot for privacy-friendly site analytics (env-gated).
- Deploy workflow now triggers on `main` instead of `master`. After merge, point DigitalOcean App Platform / deploy branch to `main` if it still tracks `master`.

## Test plan
- [ ] Confirm `dev` builds with Umami env vars unset (no script injected)
- [ ] Confirm Umami loads when `VITE_UMAMI_*` (or project equivalent) is set
- [ ] After merge: update DO deploy branch from `master` to `main` if needed
