### PR TITLE
Add Playground API presets and Documents facet configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source Quasar (Vue 3) PWA for managing multiple Meilisearch instances across development, staging, and production.
 
-**Version**: 2.2.0  
+**Version**: 2.3.0  
 **Demo**: [https://meili-manager.weeumson.com/#/](https://meili-manager.weeumson.com/#/)
 
 Credentials never leave the browser: instance URLs and API keys are stored in `localStorage` via Pinia persisted state. Do not commit secrets.
@@ -264,13 +264,14 @@ InstantSearch browser:
 
 - Query, sort, filters (advanced / LLM controls collapsed by default)
 - Display menu: compact / detailed / table, list fields, thumbnails
+- Filters panel: **Configure attributes** to choose which filterable fields show as facets (local per-index display setting), or quickly add attributes as filterable/searchable (writes Meilisearch settings and re-indexes; full reorder/remove remains under Settings → Search)
 - Click a hit to open the JSON side panel; full editor via **Open full editor** or `/documents/...`
 - Fetch by IDs when supported; **New** creates via the full editor route
 - Diagnostics: **Open in Playground** with an effective search body when available
 
 ### Playground
 
-Craft `GET`/`POST`/… requests scoped to the current index, Send, inspect status/timing/JSON, copy redacted curl (default) or with-key / HTTP / n8n workflow JSON (paste onto the n8n canvas). Seed from Documents hit or diagnostics. See [`docs/workspace-ux.md`](docs/workspace-ux.md).
+Craft `GET`/`POST`/… requests against the active instance, Send, inspect status/timing/JSON, copy redacted curl (default) or with-key / HTTP / n8n workflow JSON (paste onto the n8n canvas). Presets are grouped (Search, Documents, Index, Instance, Tasks, Keys, Experimental): Search covers hybrid, multi-search, federated (`federation.distinct` knobs), similar, and facet-search. Single-index search knobs never mutate `/multi-search`. Seed from Documents hit or diagnostics. See [`docs/workspace-ux.md`](docs/workspace-ux.md).
 
 ### Endpoints/Methods used
 

--- a/docs/workspace-ux.md
+++ b/docs/workspace-ux.md
@@ -33,6 +33,13 @@ Peer tabs (query `?tab=` is shareable):
 - Full `/documents/:index/:id` page remains the deep-link escape hatch.
 - Shortcuts: `Esc` closes the panel; `/` focuses the search query when focus is not in an input.
 
+### Documents filters and facets
+
+- The Filters panel lists Meilisearch `filterableAttributes` as InstantSearch facets.
+- **Configure attributes** (tune icon next to Clear) opens a dialog with two layers:
+  - **Show in filters**: pick which filterable attributes appear as facets. Stored per index in `indexDisplaySettings.visibleFilterAttributes` (`null` = show all). Does not write Meilisearch settings.
+  - **Index settings**: append attributes to `filterableAttributes` and/or `searchableAttributes` via `updateSettings`, wait for the task, refresh the settings cache, then refresh facets. Confirms with a re-index warning (same tone as Settings). Append only; reorder/remove stay on **Settings → Search**.
+
 ### Settings
 
 - Nested category tabs kept (Search, Relevancy, Performance, Advanced, AI).
@@ -41,6 +48,10 @@ Peer tabs (query `?tab=` is shareable):
 ### Playground
 
 - Builds live calls against the active instance (raw `fetch`, not InstantSearch).
+- Presets are grouped: **Search**, **Documents**, **Index**, **Instance**, **Tasks**, **Keys**, **Experimental** (default group: Search). Pick a group, then a chip; free-form method/path/body still works for anything without a preset.
+- Search group includes hybrid (`hybrid.embedder` + `semanticRatio`), multi-search, federated multi-search, similar, and facet-search starters.
+- **Federation knobs** appear for `POST /multi-search` when the body has `federation`. They sync only into `body.federation` (`distinct`, `limit`, `offset`) and never rewrite `queries`. Prefer `federation.distinct` over query-level `distinct` (Meilisearch returns 400 if both are set).
+- **Single-index search knobs** (q, filter, limit, offset, sort, attributesToRetrieve, hybrid) apply only to `POST /indexes/.../search`. They never run on `/multi-search`.
 - Export strip is available before Send: redacted Bearer curl by default; secondary copies include the key for local n8n/Postman.
 - **Copy n8n JSON** / **n8n + key** copy a canvas-pasteable workflow snippet (one `n8n-nodes-base.httpRequest` node, typeVersion 4.2). Paste with Ctrl/Cmd+V on the n8n canvas. Redacted uses `Bearer REDACTED`; **n8n + key** embeds the real key in the Authorization header. Node defaults: `options.timeout` 30000 ms, `retryOnFail` with `maxTries` 3 and `waitBetweenTries` 1000 ms. JSON body uses `contentType: json` + `specifyBody: json` + string `jsonBody` (Meili search/documents). Content-Type is left to the HTTP Request node; only Authorization is set as a header.
 - Documents diagnostics and hit panel can seed search or get-document requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meili-manager",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meili-manager",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@meilisearch/instant-meilisearch": "^0.31.1",
         "@quasar/cli": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meili-manager",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A Quasar app to manage multiple Meilisearch instances",
   "productName": "Meili Manager",
   "author": "bwilliamson55@github.com",

--- a/src/components/documents/DocumentsConfigureAttributesDialog.vue
+++ b/src/components/documents/DocumentsConfigureAttributesDialog.vue
@@ -1,0 +1,444 @@
+<template>
+  <q-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <q-card class="w-full" style="min-width: 320px; max-width: 560px">
+      <q-card-section class="flex items-center justify-between pb-2">
+        <div class="mm-section-title text-subtitle1">Configure attributes</div>
+        <q-btn
+          flat
+          dense
+          square
+          icon="close"
+          aria-label="Close"
+          v-close-popup
+        />
+      </q-card-section>
+      <q-separator />
+
+      <q-card-section class="flex flex-col gap-4">
+        <section>
+          <div class="mm-section-title text-subtitle2 mb-1">
+            Show in filters
+          </div>
+          <p class="text-caption text-text-muted mb-2">
+            Choose which filterable attributes appear as facets. Local only;
+            does not change Meilisearch settings. Leave empty or reset to show
+            all.
+          </p>
+          <q-select
+            v-model="localVisible"
+            :options="filterableAttributes"
+            dense
+            outlined
+            square
+            multiple
+            use-chips
+            clearable
+            label="Visible facets"
+            hint="Order follows Meilisearch filterableAttributes"
+            class="w-full"
+          />
+          <div class="flex flex-wrap gap-2 mt-2">
+            <q-btn
+              flat
+              dense
+              square
+              no-caps
+              size="sm"
+              color="primary"
+              icon="restart_alt"
+              label="Reset to all"
+              :disable="!hasVisibleSubset"
+              @click="resetVisibleToAll"
+            />
+            <q-btn
+              unelevated
+              dense
+              square
+              no-caps
+              size="sm"
+              color="primary"
+              icon="check"
+              label="Apply facets"
+              @click="applyVisibleFacets"
+            />
+          </div>
+        </section>
+
+        <q-separator />
+
+        <section>
+          <div class="mm-section-title text-subtitle2 mb-1">
+            Index settings
+          </div>
+          <p class="text-caption text-text-muted mb-2">
+            Quickly add attributes as filterable and/or searchable. Changing
+            these triggers a re-index. For reorder or remove, use Settings →
+            Search.
+          </p>
+
+          <q-banner dense class="bg-warning text-page mb-3">
+            <template #avatar>
+              <q-icon name="warning" />
+            </template>
+            <div class="text-caption">
+              {{ SETTINGS_METADATA.filterableAttributes.label }} and
+              {{ SETTINGS_METADATA.searchableAttributes.label }} changes
+              re-index all documents (may take time).
+            </div>
+          </q-banner>
+
+          <q-select
+            v-model="addFilterable"
+            :options="filterableCandidates"
+            dense
+            outlined
+            square
+            multiple
+            use-chips
+            use-input
+            input-debounce="0"
+            clearable
+            label="Add as filterable"
+            class="w-full mb-2"
+            @filter="filterCandidateOptions"
+          />
+
+          <q-checkbox
+            v-model="alsoSearchable"
+            dense
+            label="Also make searchable"
+            class="mb-2"
+            :disable="!addFilterable.length || searchableIsWildcard"
+          >
+            <q-tooltip v-if="searchableIsWildcard">
+              Searchable attributes are already ["*"] (all fields).
+            </q-tooltip>
+          </q-checkbox>
+
+          <q-select
+            v-model="addSearchable"
+            :options="searchableCandidates"
+            dense
+            outlined
+            square
+            multiple
+            use-chips
+            use-input
+            input-debounce="0"
+            clearable
+            label="Add as searchable"
+            :disable="searchableIsWildcard"
+            :hint="
+              searchableIsWildcard
+                ? 'Already searching all fields (*)'
+                : 'Appended to searchableAttributes (order unchanged)'
+            "
+            class="w-full mb-2"
+            @filter="filterSearchableOptions"
+          />
+
+          <div class="flex flex-wrap items-center gap-2 mt-1">
+            <q-btn
+              unelevated
+              dense
+              square
+              no-caps
+              size="sm"
+              color="primary"
+              icon="save"
+              label="Apply to index"
+              :loading="savingSettings"
+              :disable="!canApplyIndexSettings"
+              @click="applyIndexSettings"
+            />
+            <q-btn
+              flat
+              dense
+              square
+              no-caps
+              size="sm"
+              color="primary"
+              icon="tune"
+              label="Open Settings → Search"
+              @click="openSettingsSearch"
+            />
+          </div>
+        </section>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from "vue";
+import { useSettingsStore } from "src/meili-core/stores/settings-store";
+import { isWildcardAttributes } from "src/meili-core/utils/display-settings";
+import { SETTINGS_METADATA } from "src/meili-core/utils/settings-config";
+import {
+  confirmDialog,
+  showError,
+  showSuccess,
+} from "src/utils/notifications";
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  indexUid: {
+    type: String,
+    default: "",
+  },
+  filterableAttributes: {
+    type: Array,
+    default: () => [],
+  },
+  visibleFilterAttributes: {
+    default: null,
+    validator: (value) => value === null || Array.isArray(value),
+  },
+  searchableAttributes: {
+    type: Array,
+    default: () => [],
+  },
+  candidateAttributes: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits([
+  "update:modelValue",
+  "update:visible-filter-attributes",
+  "settings-updated",
+  "open-settings-search",
+]);
+
+const theSettings = useSettingsStore();
+
+const localVisible = ref([]);
+const addFilterable = ref([]);
+const addSearchable = ref([]);
+const alsoSearchable = ref(false);
+const savingSettings = ref(false);
+const filterableOptionFilter = ref("");
+const searchableOptionFilter = ref("");
+
+const searchableIsWildcard = computed(() =>
+  isWildcardAttributes(props.searchableAttributes),
+);
+
+const hasVisibleSubset = computed(
+  () =>
+    Array.isArray(props.visibleFilterAttributes) &&
+    props.visibleFilterAttributes.length > 0,
+);
+
+const filterableSet = computed(
+  () => new Set((props.filterableAttributes || []).filter(Boolean)),
+);
+
+const searchableSet = computed(() => {
+  if (searchableIsWildcard.value) return new Set(props.candidateAttributes);
+  return new Set((props.searchableAttributes || []).filter(Boolean));
+});
+
+const allCandidates = computed(() => {
+  const keys = new Set(
+    [...(props.candidateAttributes || []), ...(props.filterableAttributes || [])]
+      .map((k) => String(k || "").trim())
+      .filter(Boolean),
+  );
+  return [...keys].sort((a, b) => a.localeCompare(b));
+});
+
+const filterableCandidates = computed(() => {
+  const needle = filterableOptionFilter.value.trim().toLowerCase();
+  return allCandidates.value.filter((attr) => {
+    if (filterableSet.value.has(attr)) return false;
+    if (!needle) return true;
+    return attr.toLowerCase().includes(needle);
+  });
+});
+
+const searchableCandidates = computed(() => {
+  if (searchableIsWildcard.value) return [];
+  const needle = searchableOptionFilter.value.trim().toLowerCase();
+  return allCandidates.value.filter((attr) => {
+    if (searchableSet.value.has(attr)) return false;
+    if (!needle) return true;
+    return attr.toLowerCase().includes(needle);
+  });
+});
+
+const canApplyIndexSettings = computed(() => {
+  if (savingSettings.value) return false;
+  if (addFilterable.value.length > 0) return true;
+  if (!searchableIsWildcard.value && addSearchable.value.length > 0) {
+    return true;
+  }
+  return false;
+});
+
+const syncLocalVisible = () => {
+  if (
+    Array.isArray(props.visibleFilterAttributes) &&
+    props.visibleFilterAttributes.length > 0
+  ) {
+    const allowed = filterableSet.value;
+    localVisible.value = props.visibleFilterAttributes.filter((attr) =>
+      allowed.has(attr),
+    );
+    return;
+  }
+  localVisible.value = [...(props.filterableAttributes || [])];
+};
+
+watch(
+  () => [props.modelValue, props.visibleFilterAttributes, props.filterableAttributes],
+  ([open]) => {
+    if (!open) return;
+    syncLocalVisible();
+    addFilterable.value = [];
+    addSearchable.value = [];
+    alsoSearchable.value = false;
+    filterableOptionFilter.value = "";
+    searchableOptionFilter.value = "";
+  },
+);
+
+const makeOptionFilter = (targetRef) => (val, update) => {
+  update(() => {
+    targetRef.value = val ?? "";
+  });
+};
+
+const filterCandidateOptions = makeOptionFilter(filterableOptionFilter);
+const filterSearchableOptions = makeOptionFilter(searchableOptionFilter);
+
+const resetVisibleToAll = () => {
+  localVisible.value = [...(props.filterableAttributes || [])];
+  emit("update:visible-filter-attributes", null);
+};
+
+const applyVisibleFacets = () => {
+  const selected = (localVisible.value || []).filter(Boolean);
+  const all = props.filterableAttributes || [];
+  const selectedSet = new Set(selected);
+  const ordered = all.filter((attr) => selectedSet.has(attr));
+  // Empty or full selection → show all (persist null)
+  if (ordered.length === 0 || ordered.length === all.length) {
+    emit("update:visible-filter-attributes", null);
+    showSuccess("Showing all filterable facets");
+    return;
+  }
+  emit("update:visible-filter-attributes", ordered);
+  showSuccess(`Showing ${ordered.length} of ${all.length} facets`);
+};
+
+const openSettingsSearch = () => {
+  emit("open-settings-search");
+  emit("update:modelValue", false);
+};
+
+const applyIndexSettings = async () => {
+  if (!props.indexUid || !canApplyIndexSettings.value) return;
+
+  const toFilterable = [...new Set((addFilterable.value || []).filter(Boolean))];
+  let toSearchable = [...new Set((addSearchable.value || []).filter(Boolean))];
+  if (alsoSearchable.value && !searchableIsWildcard.value) {
+    toSearchable = [...new Set([...toSearchable, ...toFilterable])];
+  }
+  if (searchableIsWildcard.value) {
+    toSearchable = [];
+  }
+
+  if (!toFilterable.length && !toSearchable.length) return;
+
+  const labels = [];
+  if (toFilterable.length) {
+    labels.push(SETTINGS_METADATA.filterableAttributes.label);
+  }
+  if (toSearchable.length) {
+    labels.push(SETTINGS_METADATA.searchableAttributes.label);
+  }
+
+  const confirmed = await confirmDialog({
+    title: "Changes will trigger re-indexing",
+    message: `Updating ${labels.join(" and ")} will re-index all documents (may take time). Continue?`,
+    okLabel: "Apply and re-index",
+    okColor: "warning",
+  });
+  if (!confirmed) return;
+
+  savingSettings.value = true;
+  try {
+    const mclient = theSettings.getIndexClient(props.indexUid);
+    const current =
+      theSettings.getIndexSettingsCache(props.indexUid) ||
+      (await mclient.getSettings());
+
+    const patch = {};
+    if (toFilterable.length) {
+      const existing = (current.filterableAttributes || []).filter(
+        (field) => field && field !== "*",
+      );
+      patch.filterableAttributes = [
+        ...existing,
+        ...toFilterable.filter((attr) => !existing.includes(attr)),
+      ];
+    }
+    if (toSearchable.length) {
+      const existing = (current.searchableAttributes || []).filter(Boolean);
+      if (!isWildcardAttributes(existing)) {
+        patch.searchableAttributes = [
+          ...existing,
+          ...toSearchable.filter((attr) => !existing.includes(attr)),
+        ];
+      }
+    }
+
+    if (!Object.keys(patch).length) {
+      showSuccess("Nothing to update");
+      return;
+    }
+
+    const updateRes = await mclient.updateSettings(patch);
+    if (updateRes?.taskUid) {
+      await theSettings.waitForTask(updateRes.taskUid, {
+        intervalMs: 5000,
+      });
+    }
+
+    const updatedSettings = await mclient.getSettings();
+    theSettings.setIndexSettingsCache(props.indexUid, updatedSettings);
+    emit("settings-updated", updatedSettings);
+
+    // Keep newly filterable attrs visible when a local subset is active
+    if (
+      toFilterable.length &&
+      Array.isArray(props.visibleFilterAttributes) &&
+      props.visibleFilterAttributes.length > 0
+    ) {
+      const nextVisible = [...props.visibleFilterAttributes];
+      for (const attr of toFilterable) {
+        if (!nextVisible.includes(attr)) nextVisible.push(attr);
+      }
+      emit("update:visible-filter-attributes", nextVisible);
+    }
+
+    addFilterable.value = [];
+    addSearchable.value = [];
+    alsoSearchable.value = false;
+    showSuccess("Index attributes updated");
+  } catch (error) {
+    console.error("Configure attributes update error:", error);
+    showError(`Failed to update attributes: ${error.message}`);
+  } finally {
+    savingSettings.value = false;
+  }
+};
+</script>

--- a/src/components/documents/DocumentsFiltersPanel.vue
+++ b/src/components/documents/DocumentsFiltersPanel.vue
@@ -12,6 +12,18 @@
           </span>
         </span>
         <div class="flex gap-0.5">
+          <q-btn
+            flat
+            dense
+            square
+            size="sm"
+            icon="tune"
+            class="text-text-muted"
+            aria-label="Configure attributes"
+            @click="$emit('configure')"
+          >
+            <q-tooltip>Configure facets and filterable/searchable attributes</q-tooltip>
+          </q-btn>
           <AisClearButton label="Clear" />
           <q-btn
             flat
@@ -129,8 +141,8 @@
             v-else-if="!filterableAttributes.length"
             class="text-caption text-text-muted p-3"
           >
-            No filterable attributes on this index. Add them in the Settings tab,
-            click Submit Settings, and the facets will appear here.
+            No filterable attributes on this index. Use the tune icon to Configure
+            attributes, or add them under Settings → Search and Submit.
           </div>
         </template>
       </ais-state-results>
@@ -159,7 +171,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["close", "update:filterDensity"]);
+const emit = defineEmits(["close", "configure", "update:filterDensity"]);
 
 const attributeSearch = ref("");
 const hideZeroCounts = ref(true);

--- a/src/components/playground/PlaygroundPanel.vue
+++ b/src/components/playground/PlaygroundPanel.vue
@@ -7,9 +7,22 @@
       class="flex flex-wrap items-center gap-2 flex-shrink-0 border border-border bg-page-elevated p-2"
     >
       <span class="mm-section-kicker mr-1">Presets</span>
+      <q-select
+        v-model="activeGroupId"
+        :options="groupOptions"
+        option-value="id"
+        option-label="label"
+        emit-value
+        map-options
+        outlined
+        dense
+        square
+        label="Group"
+        class="w-40"
+      />
       <div class="flex flex-wrap items-stretch gap-1">
         <q-btn
-          v-for="tpl in templates"
+          v-for="tpl in groupTemplates"
           :key="tpl.id"
           dense
           square
@@ -148,7 +161,7 @@
             square
             label="Method"
             class="mb-3"
-            @update:model-value="onRequestEdited"
+            @update:model-value="onDraftEdited"
           />
           <q-input
             v-model="path"
@@ -158,7 +171,7 @@
             label="Path"
             hint="Relative to instance host"
             class="mb-2"
-            @update:model-value="onRequestEdited"
+            @update:model-value="onDraftEdited"
           />
         </q-card-section>
       </q-card>
@@ -185,7 +198,7 @@
               <q-tooltip>Copy JSON body</q-tooltip>
             </q-btn>
           </div>
-          <div v-if="isSearchRequest" class="mb-3">
+          <div v-if="isSingleIndexSearch" class="mb-3">
             <div class="mm-section-kicker mb-2">Search options</div>
             <div class="grid grid-cols-2 gap-2">
               <q-input
@@ -243,6 +256,68 @@
                 @update:model-value="syncKnobsToBody"
               />
             </div>
+            <div class="mm-section-kicker mt-3 mb-2">Hybrid</div>
+            <div class="grid grid-cols-2 gap-2">
+              <q-input
+                v-model="searchKnobs.hybridEmbedder"
+                outlined
+                dense
+                square
+                label="embedder"
+                hint="Required for hybrid"
+                @update:model-value="syncKnobsToBody"
+              />
+              <q-input
+                v-model.number="searchKnobs.hybridSemanticRatio"
+                type="number"
+                outlined
+                dense
+                square
+                label="semanticRatio"
+                hint="0–1"
+                min="0"
+                max="1"
+                step="0.05"
+                @update:model-value="syncKnobsToBody"
+              />
+            </div>
+          </div>
+          <div v-if="isFederatedMultiSearch" class="mb-3">
+            <div class="mm-section-kicker mb-2">Federation</div>
+            <div class="text-caption text-text-muted mb-2">
+              Syncs into body.federation only. Prefer federation.distinct over
+              query-level distinct.
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+              <q-input
+                v-model="federationKnobs.distinct"
+                outlined
+                dense
+                square
+                label="distinct"
+                hint="Attribute for federation.distinct"
+                class="col-span-2"
+                @update:model-value="syncFederationKnobsToBody"
+              />
+              <q-input
+                v-model.number="federationKnobs.limit"
+                type="number"
+                outlined
+                dense
+                square
+                label="limit"
+                @update:model-value="syncFederationKnobsToBody"
+              />
+              <q-input
+                v-model.number="federationKnobs.offset"
+                type="number"
+                outlined
+                dense
+                square
+                label="offset"
+                @update:model-value="syncFederationKnobsToBody"
+              />
+            </div>
           </div>
           <q-input
             v-model="body"
@@ -255,7 +330,7 @@
             label="JSON body"
             :placeholder="bodyPlaceholder"
             :disable="!needsBody"
-            @update:model-value="persist"
+            @update:model-value="onDraftEdited"
           />
         </q-card-section>
       </q-card>
@@ -311,13 +386,18 @@ import { computed, onMounted, reactive, ref, watch } from "vue";
 import { useSettingsStore } from "src/meili-core/stores/settings-store";
 import {
   PLAYGROUND_TEMPLATES,
+  PLAYGROUND_TEMPLATE_GROUPS,
   buildExportRequest,
   executePlaygroundRequest,
   isDestructiveMethod,
+  isMultiSearchPath,
+  isSingleIndexSearchPath,
+  resolveTemplateBody,
   serializeCurl,
   serializeHttp,
   serializeN8nJson,
 } from "src/meili-core/utils/playground-request";
+import { buildHybridConfig } from "src/meili-core/utils/search-utils";
 import { copyText } from "src/utils/clipboard";
 import { showError } from "src/utils/notifications";
 
@@ -330,15 +410,46 @@ const props = defineProps({
 
 const theSettings = useSettingsStore();
 const templates = PLAYGROUND_TEMPLATES;
+const groupOptions = PLAYGROUND_TEMPLATE_GROUPS;
 const methodOptions = ["GET", "POST", "PUT", "PATCH", "DELETE"];
 
 const TEMPLATE_HINTS = {
   search: "POST search this index",
+  hybrid: "POST search with hybrid embedder + semanticRatio",
+  "multi-search": "POST /multi-search with queries[]",
+  federated: "POST /multi-search with federation.distinct + weights",
+  similar: "POST similar documents for an id",
+  "facet-search": "POST facet search on one attribute",
   "get-document": "GET one document by id",
-  "get-settings": "GET index settings",
-  "get-stats": "GET index stats",
+  "list-documents": "GET documents page",
+  "fetch-documents": "POST documents/fetch by ids",
   "add-documents": "POST documents (write)",
   "delete-document": "DELETE one document by id",
+  "delete-documents-batch": "POST documents/delete-batch (write)",
+  "get-settings": "GET index settings",
+  "patch-settings": "PATCH index settings (write)",
+  "get-stats": "GET index stats",
+  "get-fields": "GET index fields metadata",
+  "get-index": "GET index definition",
+  health: "GET /health",
+  version: "GET /version",
+  "cluster-stats": "GET /stats",
+  "list-indexes": "GET /indexes",
+  "create-dump": "POST /dumps (write)",
+  "list-tasks": "GET /tasks",
+  "get-task": "GET /tasks/:uid",
+  "cancel-tasks": "POST /tasks/cancel (write)",
+  "delete-tasks": "POST /tasks/delete (write)",
+  "list-keys": "GET /keys",
+  "get-key": "GET /keys/:key",
+  "create-key": "POST /keys (write)",
+  "delete-key": "DELETE /keys/:key",
+  "get-experimental": "GET /experimental-features",
+  "patch-experimental": "PATCH /experimental-features (write)",
+  "list-dynamic-rules": "POST /dynamic-search-rules list",
+  "get-dynamic-rule": "GET /dynamic-search-rules/:uid",
+  "get-network": "GET /network",
+  "patch-network": "PATCH /network (write)",
 };
 
 const templateHint = (tpl) =>
@@ -352,6 +463,7 @@ const writeConfirmed = ref(false);
 const responseText = ref("");
 const responseMeta = ref(null);
 const activeTemplateId = ref(null);
+const activeGroupId = ref("search");
 
 const searchKnobs = reactive({
   q: "",
@@ -360,6 +472,14 @@ const searchKnobs = reactive({
   offset: 0,
   sort: "",
   attributesToRetrieve: "",
+  hybridEmbedder: "",
+  hybridSemanticRatio: 0.5,
+});
+
+const federationKnobs = reactive({
+  distinct: "",
+  limit: 20,
+  offset: 0,
 });
 
 const needsBody = computed(() =>
@@ -372,8 +492,26 @@ const bodyPlaceholder = computed(() =>
     : "No body for this method",
 );
 
-const isSearchRequest = computed(
-  () => method.value === "POST" && path.value.includes("/search"),
+const isSingleIndexSearch = computed(() =>
+  isSingleIndexSearchPath(method.value, path.value),
+);
+
+const isMultiSearch = computed(() =>
+  isMultiSearchPath(method.value, path.value),
+);
+
+const bodyHasFederation = computed(() => {
+  if (!isMultiSearch.value) return false;
+  try {
+    const parsed = JSON.parse(body.value || "{}");
+    return Boolean(parsed && typeof parsed === "object" && parsed.federation);
+  } catch {
+    return false;
+  }
+});
+
+const isFederatedMultiSearch = computed(
+  () => isMultiSearch.value && bodyHasFederation.value,
 );
 
 const needsWriteConfirm = computed(() =>
@@ -384,6 +522,10 @@ const hasCopyableResponse = computed(() =>
   Boolean((responseText.value || "").trim()),
 );
 
+const groupTemplates = computed(() =>
+  templates.filter((tpl) => tpl.group === activeGroupId.value),
+);
+
 const persist = () => {
   theSettings.setIndexPlaygroundState(props.indexUid, {
     method: method.value,
@@ -392,27 +534,77 @@ const persist = () => {
   });
 };
 
+const templatePath = (tpl) => tpl.path(props.indexUid);
+
 const matchActiveTemplate = () => {
-  const match = templates.find(
+  const candidates = templates.filter(
     (tpl) =>
-      tpl.method === method.value && tpl.path(props.indexUid) === path.value,
+      tpl.method === method.value && templatePath(tpl) === path.value,
   );
-  activeTemplateId.value = match?.id || null;
+  if (!candidates.length) {
+    activeTemplateId.value = null;
+    return;
+  }
+  if (candidates.length === 1) {
+    activeTemplateId.value = candidates[0].id;
+    if (candidates[0].group) activeGroupId.value = candidates[0].group;
+    return;
+  }
+  // Disambiguate search/hybrid and multi-search/federated by body shape.
+  try {
+    const parsed = JSON.parse(body.value || "{}");
+    if (parsed && typeof parsed === "object") {
+      const hasFed = Boolean(parsed.federation);
+      const hasHybrid = Boolean(parsed.hybrid);
+      const preferred = candidates.find((c) => {
+        if (c.id === "federated" || c.id === "multi-search") {
+          return hasFed ? c.id === "federated" : c.id === "multi-search";
+        }
+        if (c.id === "hybrid" || c.id === "search") {
+          return hasHybrid ? c.id === "hybrid" : c.id === "search";
+        }
+        return false;
+      });
+      if (preferred) {
+        activeTemplateId.value = preferred.id;
+        activeGroupId.value = preferred.group;
+        return;
+      }
+    }
+  } catch {
+    // fall through
+  }
+  if (candidates.some((c) => c.id === activeTemplateId.value)) {
+    const current = candidates.find((c) => c.id === activeTemplateId.value);
+    if (current?.group) activeGroupId.value = current.group;
+    return;
+  }
+  activeTemplateId.value = candidates[0].id;
+  if (candidates[0].group) activeGroupId.value = candidates[0].group;
 };
 
-const onRequestEdited = () => {
+const onDraftEdited = () => {
   matchActiveTemplate();
+  if (isSingleIndexSearch.value) syncBodyToKnobs();
+  if (isFederatedMultiSearch.value) syncBodyToFederationKnobs();
   persist();
 };
 
 const applyTemplate = (tpl) => {
   method.value = tpl.method;
-  path.value = tpl.path(props.indexUid);
-  body.value = tpl.body || "";
+  path.value = templatePath(tpl);
+  body.value = resolveTemplateBody(tpl, props.indexUid);
   writeConfirmed.value = false;
   activeTemplateId.value = tpl.id;
-  if (tpl.id === "search") {
+  if (tpl.group) activeGroupId.value = tpl.group;
+  if (isSingleIndexSearchPath(tpl.method, path.value)) {
     syncBodyToKnobs();
+  }
+  if (
+    isMultiSearchPath(tpl.method, path.value) &&
+    body.value.includes('"federation"')
+  ) {
+    syncBodyToFederationKnobs();
   }
   persist();
 };
@@ -432,12 +624,38 @@ const syncBodyToKnobs = () => {
     )
       ? parsed.attributesToRetrieve.join(",")
       : "";
+    const hybrid = parsed.hybrid;
+    if (hybrid && typeof hybrid === "object") {
+      searchKnobs.hybridEmbedder = hybrid.embedder ?? "";
+      searchKnobs.hybridSemanticRatio =
+        hybrid.semanticRatio ?? searchKnobs.hybridSemanticRatio ?? 0.5;
+    } else {
+      searchKnobs.hybridEmbedder = "";
+    }
   } catch {
     // Keep knobs as-is when body is invalid JSON.
   }
 };
 
+const syncBodyToFederationKnobs = () => {
+  try {
+    const parsed = JSON.parse(body.value || "{}");
+    const fed = parsed.federation;
+    if (!fed || typeof fed !== "object") return;
+    federationKnobs.distinct = fed.distinct ?? "";
+    federationKnobs.limit = fed.limit ?? 20;
+    federationKnobs.offset = fed.offset ?? 0;
+  } catch {
+    // Keep knobs as-is when body is invalid JSON.
+  }
+};
+
+/**
+ * Sync single-index search knobs into the body.
+ * Never call for /multi-search (would wipe queries / federation).
+ */
 const syncKnobsToBody = () => {
+  if (!isSingleIndexSearchPath(method.value, path.value)) return;
   let parsed = {};
   try {
     parsed = JSON.parse(body.value || "{}");
@@ -465,6 +683,39 @@ const syncKnobsToBody = () => {
   } else {
     delete parsed.attributesToRetrieve;
   }
+  const hybrid = buildHybridConfig({
+    enableHybrid: Boolean(String(searchKnobs.hybridEmbedder || "").trim()),
+    hybridEmbedder: searchKnobs.hybridEmbedder,
+    hybridSemanticRatio: searchKnobs.hybridSemanticRatio,
+  });
+  if (hybrid) parsed.hybrid = hybrid;
+  else delete parsed.hybrid;
+  body.value = JSON.stringify(parsed, null, 2);
+  persist();
+};
+
+/**
+ * Sync federation knobs into body.federation only (preserve queries).
+ */
+const syncFederationKnobsToBody = () => {
+  if (!isMultiSearchPath(method.value, path.value)) return;
+  let parsed = {};
+  try {
+    parsed = JSON.parse(body.value || "{}");
+  } catch {
+    parsed = {};
+  }
+  if (!parsed || typeof parsed !== "object") parsed = {};
+  if (!parsed.federation || typeof parsed.federation !== "object") {
+    parsed.federation = {};
+  }
+  const fed = { ...parsed.federation };
+  const distinct = String(federationKnobs.distinct || "").trim();
+  if (distinct) fed.distinct = distinct;
+  else delete fed.distinct;
+  fed.limit = Number(federationKnobs.limit) || 20;
+  fed.offset = Number(federationKnobs.offset) || 0;
+  parsed.federation = fed;
   body.value = JSON.stringify(parsed, null, 2);
   persist();
 };
@@ -560,14 +811,22 @@ const applySeed = (seed) => {
   persist();
 };
 
-onMounted(() => {
-  const saved = theSettings.getIndexPlaygroundState(props.indexUid);
+const loadDraftForIndex = (uid) => {
+  const saved = theSettings.getIndexPlaygroundState(uid);
   method.value = saved.method || "POST";
-  path.value = saved.path || `/indexes/${props.indexUid}/search`;
+  path.value = saved.path || `/indexes/${uid}/search`;
   body.value = saved.body || '{\n  "q": "",\n  "limit": 20\n}';
-  syncBodyToKnobs();
+  if (isSingleIndexSearchPath(method.value, path.value)) {
+    syncBodyToKnobs();
+  }
+  if (isMultiSearchPath(method.value, path.value)) {
+    syncBodyToFederationKnobs();
+  }
   matchActiveTemplate();
+};
 
+onMounted(() => {
+  loadDraftForIndex(props.indexUid);
   const seed = theSettings.consumePlaygroundSeed();
   if (seed) applySeed(seed);
 });
@@ -575,15 +834,10 @@ onMounted(() => {
 watch(
   () => props.indexUid,
   (uid) => {
-    const saved = theSettings.getIndexPlaygroundState(uid);
-    method.value = saved.method || "POST";
-    path.value = saved.path || `/indexes/${uid}/search`;
-    body.value = saved.body || '{\n  "q": "",\n  "limit": 20\n}';
-    syncBodyToKnobs();
     writeConfirmed.value = false;
     responseText.value = "";
     responseMeta.value = null;
-    matchActiveTemplate();
+    loadDraftForIndex(uid);
   },
 );
 

--- a/src/meili-core/stores/settings-store.js
+++ b/src/meili-core/stores/settings-store.js
@@ -33,7 +33,7 @@ export const useSettingsStore = defineStore("settings", {
     currentInstance: null,
     instances: [],
     // Per-index display preferences
-    indexDisplaySettings: {}, // { indexName: { imageField, listFields, listColumns, listViewMode, compactFieldLimit } }
+    indexDisplaySettings: {}, // { indexName: { imageField, listFields, listColumns, listViewMode, compactFieldLimit, visibleFilterAttributes } }
     // Per-index search state persistence
     indexSearchState: {}, // { indexName: { query: '', filters: {}, sort: '', page: 0, filtersVisible: true, ...search options } }
     // Latest Meilisearch index settings fetched or saved in-session

--- a/src/meili-core/utils/display-settings.js
+++ b/src/meili-core/utils/display-settings.js
@@ -19,6 +19,8 @@ export const DEFAULT_DISPLAY_SETTINGS = Object.freeze({
   listColumns: 2,
   listViewMode: "compact",
   compactFieldLimit: 4,
+  /** null / omitted = show all filterable attributes as facets */
+  visibleFilterAttributes: null,
 });
 
 export const COMPACT_FIELD_CANDIDATES = [
@@ -158,6 +160,27 @@ export const resolveFilterableAttributes = (
   }
 
   return [];
+};
+
+/**
+ * Intersect Meili filterable attributes with a local display subset.
+ * null / omitted / empty visibleFilterAttributes → show all filterable (Meili order).
+ */
+export const resolveVisibleFilterAttributes = (
+  filterableAttributes = [],
+  visibleFilterAttributes = null,
+) => {
+  if (!Array.isArray(filterableAttributes) || filterableAttributes.length === 0) {
+    return [];
+  }
+  if (
+    !Array.isArray(visibleFilterAttributes) ||
+    visibleFilterAttributes.length === 0
+  ) {
+    return [...filterableAttributes];
+  }
+  const visible = new Set(visibleFilterAttributes.filter(Boolean));
+  return filterableAttributes.filter((attr) => visible.has(attr));
 };
 
 export const shouldUseAllItemFields = ({

--- a/src/meili-core/utils/playground-request.js
+++ b/src/meili-core/utils/playground-request.js
@@ -1,15 +1,150 @@
 import { normalizeMeiliHost } from "./meili-client";
 
+/** Preset group order for Playground UI (default: Search). */
+export const PLAYGROUND_TEMPLATE_GROUPS = [
+  { id: "search", label: "Search" },
+  { id: "documents", label: "Documents" },
+  { id: "index", label: "Index" },
+  { id: "instance", label: "Instance" },
+  { id: "tasks", label: "Tasks" },
+  { id: "keys", label: "Keys" },
+  { id: "experimental", label: "Experimental" },
+];
+
+/**
+ * True when this is a single-index search endpoint (not /multi-search).
+ * @param {string} method
+ * @param {string} path
+ */
+export function isSingleIndexSearchPath(method, path = "") {
+  if (String(method || "").toUpperCase() !== "POST") return false;
+  return /\/indexes\/[^/]+\/search\/?(\?|$)/.test(String(path || ""));
+}
+
+/**
+ * True when this is the multi-search endpoint.
+ * @param {string} method
+ * @param {string} path
+ */
+export function isMultiSearchPath(method, path = "") {
+  if (String(method || "").toUpperCase() !== "POST") return false;
+  return /\/multi-search\/?(\?|$)/.test(String(path || ""));
+}
+
+/**
+ * @param {string} uid
+ */
+function multiSearchBody(uid) {
+  return JSON.stringify(
+    {
+      queries: [
+        {
+          indexUid: uid,
+          q: "",
+          limit: 20,
+        },
+      ],
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Federated starter: federation.distinct + sample federationOptions.weight.
+ * No query-level distinct (Meili 400 if both are set).
+ * @param {string} uid
+ */
+function federatedMultiSearchBody(uid) {
+  return JSON.stringify(
+    {
+      federation: {
+        limit: 20,
+        offset: 0,
+        distinct: "",
+      },
+      queries: [
+        {
+          indexUid: uid,
+          q: "",
+          federationOptions: {
+            weight: 1.0,
+          },
+        },
+      ],
+    },
+    null,
+    2,
+  );
+}
+
 export const PLAYGROUND_TEMPLATES = [
+  // —— Search ——
   {
     id: "search",
+    group: "search",
     label: "Search",
     method: "POST",
     path: (uid) => `/indexes/${uid}/search`,
     body: '{\n  "q": "",\n  "limit": 20\n}',
   },
   {
+    id: "hybrid",
+    group: "search",
+    label: "Hybrid",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/search`,
+    body: () =>
+      JSON.stringify(
+        {
+          q: "",
+          limit: 20,
+          hybrid: {
+            embedder: "default",
+            semanticRatio: 0.5,
+          },
+        },
+        null,
+        2,
+      ),
+  },
+  {
+    id: "multi-search",
+    group: "search",
+    label: "Multi-search",
+    method: "POST",
+    path: () => "/multi-search",
+    body: (uid) => multiSearchBody(uid),
+  },
+  {
+    id: "federated",
+    group: "search",
+    label: "Federated",
+    method: "POST",
+    path: () => "/multi-search",
+    body: (uid) => federatedMultiSearchBody(uid),
+  },
+  {
+    id: "similar",
+    group: "search",
+    label: "Similar",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/similar`,
+    body: '{\n  "id": ":id",\n  "limit": 20,\n  "embedder": "default"\n}',
+  },
+  {
+    id: "facet-search",
+    group: "search",
+    label: "Facet search",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/facet-search`,
+    body: '{\n  "facetName": "",\n  "facetQuery": "",\n  "q": ""\n}',
+  },
+
+  // —— Documents ——
+  {
     id: "get-document",
+    group: "documents",
     label: "Get document",
     method: "GET",
     path: (uid, docId = ":id") =>
@@ -17,21 +152,24 @@ export const PLAYGROUND_TEMPLATES = [
     body: "",
   },
   {
-    id: "get-settings",
-    label: "Get settings",
+    id: "list-documents",
+    group: "documents",
+    label: "List documents",
     method: "GET",
-    path: (uid) => `/indexes/${uid}/settings`,
+    path: (uid) => `/indexes/${uid}/documents?limit=20&offset=0`,
     body: "",
   },
   {
-    id: "get-stats",
-    label: "Get stats",
-    method: "GET",
-    path: (uid) => `/indexes/${uid}/stats`,
-    body: "",
+    id: "fetch-documents",
+    group: "documents",
+    label: "Fetch by IDs",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/documents/fetch`,
+    body: '{\n  "ids": [":id"]\n}',
   },
   {
     id: "add-documents",
+    group: "documents",
     label: "Add documents",
     method: "POST",
     path: (uid) => `/indexes/${uid}/documents`,
@@ -39,13 +177,234 @@ export const PLAYGROUND_TEMPLATES = [
   },
   {
     id: "delete-document",
+    group: "documents",
     label: "Delete document",
     method: "DELETE",
     path: (uid, docId = ":id") =>
       `/indexes/${uid}/documents/${encodeURIComponent(docId)}`,
     body: "",
   },
+  {
+    id: "delete-documents-batch",
+    group: "documents",
+    label: "Delete batch",
+    method: "POST",
+    path: (uid) => `/indexes/${uid}/documents/delete-batch`,
+    body: '[\n  ":id"\n]',
+  },
+
+  // —— Index ——
+  {
+    id: "get-settings",
+    group: "index",
+    label: "Get settings",
+    method: "GET",
+    path: (uid) => `/indexes/${uid}/settings`,
+    body: "",
+  },
+  {
+    id: "patch-settings",
+    group: "index",
+    label: "Patch settings",
+    method: "PATCH",
+    path: (uid) => `/indexes/${uid}/settings`,
+    body: "{\n  \n}",
+  },
+  {
+    id: "get-stats",
+    group: "index",
+    label: "Get stats",
+    method: "GET",
+    path: (uid) => `/indexes/${uid}/stats`,
+    body: "",
+  },
+  {
+    id: "get-fields",
+    group: "index",
+    label: "Fields",
+    method: "GET",
+    path: (uid) => `/indexes/${uid}/fields`,
+    body: "",
+  },
+  {
+    id: "get-index",
+    group: "index",
+    label: "Get index",
+    method: "GET",
+    path: (uid) => `/indexes/${uid}`,
+    body: "",
+  },
+
+  // —— Instance ——
+  {
+    id: "health",
+    group: "instance",
+    label: "Health",
+    method: "GET",
+    path: () => "/health",
+    body: "",
+  },
+  {
+    id: "version",
+    group: "instance",
+    label: "Version",
+    method: "GET",
+    path: () => "/version",
+    body: "",
+  },
+  {
+    id: "cluster-stats",
+    group: "instance",
+    label: "Cluster stats",
+    method: "GET",
+    path: () => "/stats",
+    body: "",
+  },
+  {
+    id: "list-indexes",
+    group: "instance",
+    label: "List indexes",
+    method: "GET",
+    path: () => "/indexes",
+    body: "",
+  },
+  {
+    id: "create-dump",
+    group: "instance",
+    label: "Create dump",
+    method: "POST",
+    path: () => "/dumps",
+    body: "",
+  },
+
+  // —— Tasks ——
+  {
+    id: "list-tasks",
+    group: "tasks",
+    label: "List tasks",
+    method: "GET",
+    path: () => "/tasks?limit=20",
+    body: "",
+  },
+  {
+    id: "get-task",
+    group: "tasks",
+    label: "Get task",
+    method: "GET",
+    path: () => "/tasks/:uid",
+    body: "",
+  },
+  {
+    id: "cancel-tasks",
+    group: "tasks",
+    label: "Cancel tasks",
+    method: "POST",
+    path: () => "/tasks/cancel",
+    body: '{\n  "uids": []\n}',
+  },
+  {
+    id: "delete-tasks",
+    group: "tasks",
+    label: "Delete tasks",
+    method: "POST",
+    path: () => "/tasks/delete",
+    body: '{\n  "uids": []\n}',
+  },
+
+  // —— Keys ——
+  {
+    id: "list-keys",
+    group: "keys",
+    label: "List keys",
+    method: "GET",
+    path: () => "/keys",
+    body: "",
+  },
+  {
+    id: "get-key",
+    group: "keys",
+    label: "Get key",
+    method: "GET",
+    path: () => "/keys/:key",
+    body: "",
+  },
+  {
+    id: "create-key",
+    group: "keys",
+    label: "Create key",
+    method: "POST",
+    path: () => "/keys",
+    body: '{\n  "description": "",\n  "actions": ["search"],\n  "indexes": ["*"],\n  "expiresAt": null\n}',
+  },
+  {
+    id: "delete-key",
+    group: "keys",
+    label: "Delete key",
+    method: "DELETE",
+    path: () => "/keys/:key",
+    body: "",
+  },
+
+  // —— Experimental ——
+  {
+    id: "get-experimental",
+    group: "experimental",
+    label: "Get experimental",
+    method: "GET",
+    path: () => "/experimental-features",
+    body: "",
+  },
+  {
+    id: "patch-experimental",
+    group: "experimental",
+    label: "Patch experimental",
+    method: "PATCH",
+    path: () => "/experimental-features",
+    body: '{\n  "dynamicSearchRules": true\n}',
+  },
+  {
+    id: "list-dynamic-rules",
+    group: "experimental",
+    label: "List dynamic rules",
+    method: "POST",
+    path: () => "/dynamic-search-rules",
+    body: '{\n  "offset": 0,\n  "limit": 20\n}',
+  },
+  {
+    id: "get-dynamic-rule",
+    group: "experimental",
+    label: "Get dynamic rule",
+    method: "GET",
+    path: () => "/dynamic-search-rules/:uid",
+    body: "",
+  },
+  {
+    id: "get-network",
+    group: "experimental",
+    label: "Get network",
+    method: "GET",
+    path: () => "/network",
+    body: "",
+  },
+  {
+    id: "patch-network",
+    group: "experimental",
+    label: "Patch network",
+    method: "PATCH",
+    path: () => "/network",
+    body: "{\n  \n}",
+  },
 ];
+
+/**
+ * Resolve a template body (string or uid => string).
+ * @param {{ body?: string | ((uid: string) => string) }} tpl
+ * @param {string} uid
+ */
+export function resolveTemplateBody(tpl, uid) {
+  if (typeof tpl.body === "function") return tpl.body(uid) || "";
+  return tpl.body || "";
+}
 
 /**
  * @param {string} host
@@ -259,6 +618,17 @@ export function isDestructiveMethod(method, path = "") {
     ["POST", "PUT", "PATCH"].includes(m) &&
     /\/documents(\/|$|\?)/.test(path) &&
     !/\/documents\/fetch/.test(path)
+  ) {
+    return true;
+  }
+  // Task cancel/delete and dump creation mutate cluster state.
+  if (m === "POST" && /\/(tasks\/(cancel|delete)|dumps)\/?(\?|$)/.test(path)) {
+    return true;
+  }
+  // Keys create / experimental + network patches.
+  if (
+    ["POST", "PUT", "PATCH"].includes(m) &&
+    /\/(keys|experimental-features|network)\/?(\?|$)/.test(path)
   ) {
     return true;
   }

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -186,9 +186,10 @@
               <template #before>
                 <div class="pr-2 h-full min-h-0">
                   <DocumentsFiltersPanel
-                    :filterable-attributes="filterableAttributes"
+                    :filterable-attributes="visibleFilterableAttributes"
                     :filter-density="savedSearchState.filterDensity"
                     @update:filter-density="onFilterDensityChange"
+                    @configure="showConfigureAttributesDialog = true"
                     @close="filtersVisible = false"
                   />
                 </div>
@@ -282,6 +283,18 @@
       :fields="displaySettings.listFields"
       @update:fields="onListFieldsOrderChange"
     />
+
+    <DocumentsConfigureAttributesDialog
+      v-model="showConfigureAttributesDialog"
+      :index-uid="currentIndex || route.params.uid"
+      :filterable-attributes="allFilterableAttributes"
+      :visible-filter-attributes="displaySettings.visibleFilterAttributes"
+      :searchable-attributes="iSettings.searchableAttributes || []"
+      :candidate-attributes="attributeCandidates"
+      @update:visible-filter-attributes="onVisibleFilterAttributesChange"
+      @settings-updated="onIndexSettingsUpdated"
+      @open-settings-search="openSettingsSearchTab"
+    />
   </q-page>
 </template>
 
@@ -316,9 +329,11 @@ import DocumentsHitsColumn from "components/documents/DocumentsHitsColumn.vue";
 import DocumentsDisplayMenu from "components/documents/DocumentsDisplayMenu.vue";
 import DocumentSidePanel from "components/documents/DocumentSidePanel.vue";
 import ListFieldsOrderDialog from "components/documents/ListFieldsOrderDialog.vue";
+import DocumentsConfigureAttributesDialog from "components/documents/DocumentsConfigureAttributesDialog.vue";
 import {
   resolveListFields,
   resolveFilterableAttributes,
+  resolveVisibleFilterAttributes,
   shouldUseAllItemFields,
   getListFieldsSourceLabel,
   mergeDisplaySettings,
@@ -398,6 +413,7 @@ const listColumnOptions = [
   { label: "3 cols", value: 3 },
 ];
 const showListFieldsOrderDialog = ref(false);
+const showConfigureAttributesDialog = ref(false);
 const filtersVisible = ref(true);
 const filtersPanelWidth = ref(380);
 const previousIndex = ref("");
@@ -425,6 +441,25 @@ const matchingStrategyOptions = [
   { label: "Frequency", value: "frequency" },
 ];
 
+const allFilterableAttributes = computed(() => {
+  const cached =
+    theSettings.getIndexSettingsCache(currentIndex.value) || iSettings.value;
+  return resolveFilterableAttributes(cached, fieldsRows.value);
+});
+
+const visibleFilterableAttributes = computed(() =>
+  resolveVisibleFilterAttributes(
+    allFilterableAttributes.value,
+    displaySettings.value.visibleFilterAttributes,
+  ),
+);
+
+const attributeCandidates = computed(() => {
+  const fromDistribution = fdRows.value.map((row) => row["Field Name"]);
+  const fromFields = fieldsRows.value.map((row) => row.field);
+  return [...new Set([...fromDistribution, ...fromFields].filter(Boolean))];
+});
+
 const searchParams = computed(() => {
   const compatParams = buildCompatibleSearchParams(
     savedSearchState.value,
@@ -446,8 +481,8 @@ const searchParams = computed(() => {
   if (Object.keys(refinementList).length > 0) {
     params.refinementList = refinementList;
   }
-  if (filterableAttributes.value.length > 0) {
-    params.facets = filterableAttributes.value;
+  if (visibleFilterableAttributes.value.length > 0) {
+    params.facets = visibleFilterableAttributes.value;
   }
   return params;
 });
@@ -690,12 +725,6 @@ const resolvedListFields = computed(() =>
   }),
 );
 
-const filterableAttributes = computed(() => {
-  const cached =
-    theSettings.getIndexSettingsCache(currentIndex.value) || iSettings.value;
-  return resolveFilterableAttributes(cached, fieldsRows.value);
-});
-
 const syncIndexSettings = (settings) => {
   if (!settings || !currentIndex.value) return;
   theSettings.setIndexSettingsCache(currentIndex.value, settings);
@@ -705,6 +734,18 @@ const syncIndexSettings = (settings) => {
 
 const onIndexSettingsUpdated = (settings) => {
   syncIndexSettings(settings);
+};
+
+const onVisibleFilterAttributesChange = (next) => {
+  displaySettings.value = {
+    ...displaySettings.value,
+    visibleFilterAttributes: next,
+  };
+  saveDisplaySettings();
+};
+
+const openSettingsSearchTab = () => {
+  detailPanelTab.value = "settings";
 };
 
 const useAllItemFields = computed(() =>


### PR DESCRIPTION
- Grouped Playground presets with hybrid and federation knobs that stay on the right endpoints
- Added Configure attributes for visible facets and quick filterable/searchable appends
- DRY draft hydrate/edit handlers and document the new UX; bump to 2.3.0