### PR TITLE
Fix Documents filter persist and Playground search bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source Quasar (Vue 3) PWA for managing multiple Meilisearch instances across development, staging, and production.
 
-**Version**: 2.3.0  
+**Version**: 2.3.1  
 **Demo**: [https://meili-manager.weeumson.com/#/](https://meili-manager.weeumson.com/#/)
 
 Credentials never leave the browser: instance URLs and API keys are stored in `localStorage` via Pinia persisted state. Do not commit secrets.

--- a/docs/workspace-ux.md
+++ b/docs/workspace-ux.md
@@ -33,6 +33,12 @@ Peer tabs (query `?tab=` is shareable):
 - Full `/documents/:index/:id` page remains the deep-link escape hatch.
 - Shortcuts: `Esc` closes the panel; `/` focuses the search query when focus is not in an input.
 
+### Documents search persistence and Playground bridge
+
+- Index tabs use `keep-alive` so leaving Documents for Playground/Settings/Overview does not destroy InstantSearch.
+- `SearchStateWatcher` also guards against empty `refinementList` snapshots on unmount / remount grace (teardown often kept `query` but dropped facets, which wiped filters while the query stuck).
+- Toolbar and Search Diagnostics: **Open in Playground** and **Copy search JSON** build a Meilisearch body from `indexSearchState` via pure helpers in `src/meili-core/utils/search-utils.js` (`filtersToMeiliFilter`, `instantSortToMeiliSort`, `buildMeiliSearchBodyFromIndexState`). Body includes `q`, `filter`, `sort`, `limit`/`offset`, plus compat/hybrid fields when applicable. Seed uses `setPlaygroundSeed({ type: "search", indexUid, body })`; Playground `applySeed` syncs knobs from the body.
+
 ### Documents filters and facets
 
 - The Filters panel lists Meilisearch `filterableAttributes` as InstantSearch facets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meili-manager",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meili-manager",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@meilisearch/instant-meilisearch": "^0.31.1",
         "@quasar/cli": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meili-manager",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A Quasar app to manage multiple Meilisearch instances",
   "productName": "Meili Manager",
   "author": "bwilliamson55@github.com",

--- a/src/components/IndexDetailTabs.vue
+++ b/src/components/IndexDetailTabs.vue
@@ -27,6 +27,7 @@
       <q-tab-panels
         v-model="tabModel"
         animated
+        keep-alive
         class="flex-1 min-h-0 bg-transparent"
       >
         <q-tab-panel name="documents" class="p-0 flex flex-col flex-1 min-h-0">

--- a/src/components/SearchStateWatcher.vue
+++ b/src/components/SearchStateWatcher.vue
@@ -22,20 +22,60 @@ const emit = defineEmits(["state-changed"]);
 const theSettings = useSettingsStore();
 const isInitialized = ref(false);
 const hasSeenNonEmptyState = ref(false);
+/** After remount, InstantSearch may briefly report empty refinementList. */
+const restoreGraceUntil = ref(0);
 
-const persistFromInstantSearchState = (newState) => {
+const hasFilterValues = (filters = {}) =>
+  Object.values(filters).some(
+    (values) => Array.isArray(values) && values.length > 0,
+  );
+
+const extractFilters = (state) => {
+  const filters = {};
+  if (state?.refinementList) {
+    Object.keys(state.refinementList).forEach((key) => {
+      if (state.refinementList[key] && state.refinementList[key].length > 0) {
+        filters[key] = state.refinementList[key];
+      }
+    });
+  }
+  return filters;
+};
+
+/**
+ * Persist InstantSearch UI state into indexSearchState.
+ * @param {object} newState
+ * @param {{ preserveFiltersIfEmpty?: boolean }} [opts]
+ *   When true (unmount / restore grace), do not overwrite saved facet filters
+ *   with an empty map. Teardown and remount often keep `query` but drop
+ *   `refinementList`, which previously wiped filters while the query stuck.
+ */
+const persistFromInstantSearchState = (newState, opts = {}) => {
   if (!newState || !props.indexName) return;
+
+  const existingState = theSettings.getIndexSearchState(props.indexName);
+  let filters = extractFilters(newState);
+  const preserveFiltersIfEmpty =
+    opts.preserveFiltersIfEmpty || Date.now() < restoreGraceUntil.value;
+
+  if (
+    preserveFiltersIfEmpty &&
+    !hasFilterValues(filters) &&
+    hasFilterValues(existingState.filters)
+  ) {
+    filters = { ...existingState.filters };
+  }
 
   const searchState = {
     query: newState.query || "",
-    filters: extractFilters(newState),
+    filters,
     sort: newState.sortBy || "",
     page: newState.page !== undefined ? newState.page : 0,
   };
 
   const hasState =
     searchState.query ||
-    Object.keys(searchState.filters).length > 0 ||
+    hasFilterValues(searchState.filters) ||
     searchState.sort ||
     searchState.page > 0;
 
@@ -49,7 +89,6 @@ const persistFromInstantSearchState = (newState) => {
   }
 
   if (hasSeenNonEmptyState.value || hasState) {
-    const existingState = theSettings.getIndexSearchState(props.indexName);
     theSettings.setIndexSearchState(props.indexName, {
       ...existingState,
       ...searchState,
@@ -58,7 +97,6 @@ const persistFromInstantSearchState = (newState) => {
   }
 };
 
-// Watch for state changes and save them
 watch(
   () => props.state,
   (newState) => {
@@ -67,18 +105,19 @@ watch(
   { deep: true },
 );
 
-// Mark as initialized after a short delay to allow ais-configure to apply saved state
 onMounted(() => {
-  // Give ais-configure time to apply the saved state before we start watching
+  // Allow ais-configure to re-apply saved query/filters before empty snapshots win.
+  restoreGraceUntil.value = Date.now() + 500;
   setTimeout(() => {
     isInitialized.value = true;
-    // If we haven't seen a non-empty state yet, check if current state has any value
     const currentState = props.state;
     if (currentState) {
       const hasState =
         currentState.query ||
         (currentState.refinementList &&
-          Object.keys(currentState.refinementList).length > 0) ||
+          Object.keys(currentState.refinementList).some(
+            (key) => currentState.refinementList[key]?.length > 0,
+          )) ||
         currentState.sortBy ||
         (currentState.page !== undefined && currentState.page > 0);
       if (hasState) {
@@ -89,19 +128,8 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  persistFromInstantSearchState(props.state);
+  // Tab switches destroy the Documents panel (unless keep-alive). InstantSearch
+  // teardown often still has query/sort but an empty refinementList.
+  persistFromInstantSearchState(props.state, { preserveFiltersIfEmpty: true });
 });
-
-// Helper to extract filters from state
-function extractFilters(state) {
-  const filters = {};
-  if (state.refinementList) {
-    Object.keys(state.refinementList).forEach((key) => {
-      if (state.refinementList[key] && state.refinementList[key].length > 0) {
-        filters[key] = state.refinementList[key];
-      }
-    });
-  }
-  return filters;
-}
 </script>

--- a/src/components/aisComponents/AisSearchDiagnostics.vue
+++ b/src/components/aisComponents/AisSearchDiagnostics.vue
@@ -1,6 +1,6 @@
 <template>
   <ais-state-results>
-    <template #default="{ results, state }">
+    <template #default="{ results }">
       <q-expansion-item
         dense
         dense-toggle
@@ -21,8 +21,26 @@
                 color="primary"
                 icon="terminal"
                 label="Open in Playground"
-                @click="openInPlayground(state)"
-              />
+                @click="$emit('open-playground')"
+              >
+                <q-tooltip>
+                  Seed Playground from the saved Documents search state
+                </q-tooltip>
+              </q-btn>
+              <q-btn
+                flat
+                dense
+                square
+                no-caps
+                size="sm"
+                icon="content_copy"
+                label="Copy search JSON"
+                @click="$emit('copy-search-json')"
+              >
+                <q-tooltip>
+                  Copy the Meilisearch search body as JSON
+                </q-tooltip>
+              </q-btn>
             </div>
             <div class="mb-2">
               <strong>Request UID:</strong>
@@ -76,7 +94,7 @@
 </template>
 
 <script setup>
-const props = defineProps({
+defineProps({
   headerEnabled: {
     type: Boolean,
     default: false,
@@ -103,7 +121,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["open-playground"]);
+defineEmits(["open-playground", "copy-search-json"]);
 
 const getFirstHitValue = (results, key) => {
   const firstHit = results?.hits?.[0];
@@ -116,24 +134,5 @@ const formatValue = (value) => {
     return JSON.stringify(value);
   }
   return String(value);
-};
-
-const openInPlayground = (state) => {
-  const body = {
-    q: state?.query || "",
-    limit: state?.hitsPerPage || 20,
-  };
-  const embedder = props.hybridEmbedder?.trim();
-  if (props.hybridEnabled && embedder) {
-    body.hybrid = {
-      embedder,
-      semanticRatio: props.hybridSemanticRatio ?? 0.5,
-    };
-  }
-  emit("open-playground", {
-    type: "search",
-    indexUid: props.indexUid,
-    body,
-  });
 };
 </script>

--- a/src/meili-core/README.md
+++ b/src/meili-core/README.md
@@ -57,7 +57,7 @@ await useIndexesStore().fetchIndexes();
 Treat these as the public API. Refactor internals freely, but keep these signatures:
 
 - `settings-store`: `validateConnection()`, `getIndexClient(indexName)`, `rawRequest(path, options)`, `getIndexSearchState(indexName)`, `setIndexSearchState(indexName, state)`, `getIndexDisplaySettings(indexName)`, `setIndexDisplaySettings(indexName, settings)`, `getIndexSettingsCache(indexName)`, `setIndexSettingsCache(indexName, settings)`, `setLastIndexVisit(indexUid, tab)`, `getIndexPlaygroundState(indexName)`, `setIndexPlaygroundState(indexName, state)`, `setPlaygroundSeed(seed)`, `consumePlaygroundSeed()`
-- `utils/search-utils`: default search state + hybrid config helpers
+- `utils/search-utils`: default search state, hybrid config, Documents→Playground body helpers (`filtersToMeiliFilter`, `instantSortToMeiliSort`, `buildMeiliSearchBodyFromIndexState`)
 - `utils/display-settings`: list field resolution, document id/title helpers, `DEFAULT_DISPLAY_SETTINGS`, `mergeDisplaySettings()`
 - `utils/playground-request`: URL/curl/HTTP/n8n (canvas-pasteable HTTP Request node) serialization + `executePlaygroundRequest`
 - `utils/settings-config`: `SETTINGS_METADATA` (drives any settings UI)

--- a/src/meili-core/utils/search-utils.js
+++ b/src/meili-core/utils/search-utils.js
@@ -139,3 +139,88 @@ export const hasActiveSavedSearch = (state = {}) => {
     state.query?.trim() || hasFilters || state.sort || (state.page ?? 0) > 0,
   );
 };
+
+/** Escape a filter value for Meilisearch filter expressions. */
+export const escapeMeiliFilterValue = (value) => {
+  const str = String(value ?? "");
+  return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+};
+
+/**
+ * InstantSearch refinement map `{ attr: string[] }` → Meili filter string.
+ * AND across attributes, OR within an attribute.
+ */
+export const filtersToMeiliFilter = (filters = {}) => {
+  const clauses = [];
+  for (const [attribute, values] of Object.entries(filters || {})) {
+    if (!attribute || !Array.isArray(values) || values.length === 0) continue;
+    const parts = values.map(
+      (value) => `${attribute} = ${escapeMeiliFilterValue(value)}`,
+    );
+    clauses.push(parts.length === 1 ? parts[0] : `(${parts.join(" OR ")})`);
+  }
+  return clauses.length > 0 ? clauses.join(" AND ") : undefined;
+};
+
+/**
+ * Strip InstantSearch `indexUid:attr:dir` sort values to Meili `["attr:dir"]`.
+ * Relevance (sort equals indexUid, or empty) returns undefined.
+ */
+export const instantSortToMeiliSort = (sortBy, indexUid = "") => {
+  if (!sortBy || typeof sortBy !== "string") return undefined;
+  const trimmed = sortBy.trim();
+  if (!trimmed) return undefined;
+  if (indexUid && trimmed === indexUid) return undefined;
+
+  const prefix = indexUid ? `${indexUid}:` : "";
+  if (prefix && trimmed.startsWith(prefix)) {
+    const rest = trimmed.slice(prefix.length);
+    if (/^.+:(asc|desc)$/i.test(rest)) return [rest];
+    return undefined;
+  }
+
+  if (/^.+:(asc|desc)$/i.test(trimmed)) return [trimmed];
+  return undefined;
+};
+
+/**
+ * Build a faithful Meilisearch POST /search body from Documents indexSearchState.
+ *
+ * @param {object} savedSearchState
+ * @param {{
+ *   hitsPerPage?: number,
+ *   indexUid?: string,
+ *   compatParams?: Record<string, unknown>,
+ * }} [options]
+ *   Pass `compatParams` from `buildCompatibleSearchParams` to include
+ *   matchingStrategy / distinct / ranking flags / hybrid with version gating.
+ */
+export const buildMeiliSearchBodyFromIndexState = (
+  savedSearchState = {},
+  { hitsPerPage = 20, indexUid = "", compatParams } = {},
+) => {
+  const limit = Number(hitsPerPage) > 0 ? Number(hitsPerPage) : 20;
+  const page = Math.max(Number(savedSearchState.page) || 0, 0);
+  const body = {
+    q: savedSearchState.query || "",
+    limit,
+    offset: page * limit,
+  };
+
+  const filter = filtersToMeiliFilter(savedSearchState.filters);
+  if (filter) body.filter = filter;
+
+  const sort = instantSortToMeiliSort(savedSearchState.sort, indexUid);
+  if (sort) body.sort = sort;
+
+  if (compatParams && typeof compatParams === "object") {
+    for (const [key, value] of Object.entries(compatParams)) {
+      if (value !== undefined) body[key] = value;
+    }
+  } else {
+    const hybrid = buildHybridConfig(savedSearchState);
+    if (hybrid) body.hybrid = hybrid;
+  }
+
+  return body;
+};

--- a/src/pages/IndexDetailPage.vue
+++ b/src/pages/IndexDetailPage.vue
@@ -118,6 +118,34 @@
                 :label="filtersVisible ? 'Hide filters' : 'Show filters'"
                 @click="filtersVisible = !filtersVisible"
               />
+              <q-btn
+                outline
+                dense
+                square
+                no-caps
+                color="primary"
+                icon="terminal"
+                label="Open in Playground"
+                @click="openSearchInPlayground"
+              >
+                <q-tooltip>
+                  Seed Playground with the current search body (q, filter, sort,
+                  limit/offset, hybrid)
+                </q-tooltip>
+              </q-btn>
+              <q-btn
+                flat
+                dense
+                square
+                no-caps
+                icon="content_copy"
+                label="Copy search JSON"
+                @click="copyCurrentSearchJson"
+              >
+                <q-tooltip>
+                  Copy the Meilisearch search body as JSON
+                </q-tooltip>
+              </q-btn>
             </div>
             <div class="flex flex-wrap items-center gap-2">
               <q-input
@@ -216,6 +244,7 @@
                 normalizeThreshold(savedSearchState.hybridSemanticRatio)
               "
               @open-playground="openSearchInPlayground"
+              @copy-search-json="copyCurrentSearchJson"
             />
             <ais-configure v-bind="searchParams" />
             <SearchStatePersistence
@@ -306,6 +335,7 @@ import {
   normalizeThreshold,
   getDefaultIndexSearchState,
   buildRefinementListFromFilters,
+  buildMeiliSearchBodyFromIndexState,
   getLlmPresetPatch,
   getClearedLlmPresetFields,
   getDefaultEmbedderName,
@@ -339,6 +369,7 @@ import {
   mergeDisplaySettings,
 } from "src/meili-core/utils/display-settings";
 import { showError, showSuccess } from "src/utils/notifications";
+import { copyText } from "src/utils/clipboard";
 
 const route = useRoute();
 const router = useRouter();
@@ -434,6 +465,7 @@ const batchFetchedColumns = [
 // Search state persistence
 // Note: page is 0-based to match InstantSearch's internal format (0 = first page, 1 = second page)
 const savedSearchState = ref(getDefaultIndexSearchState());
+const DOCUMENTS_HITS_PER_PAGE = 50;
 
 const matchingStrategyOptions = [
   { label: "Last", value: "last" },
@@ -469,7 +501,7 @@ const searchParams = computed(() => {
     savedSearchState.value.filters,
   );
   const params = {
-    hitsPerPage: 50,
+    hitsPerPage: DOCUMENTS_HITS_PER_PAGE,
     query: savedSearchState.value.query || undefined,
     sortBy: savedSearchState.value.sort || undefined,
     page:
@@ -597,6 +629,16 @@ const onHitSelect = ({ item, documentId }) => {
   docPanelOpen.value = true;
 };
 
+const buildCurrentSearchBody = () =>
+  buildMeiliSearchBodyFromIndexState(savedSearchState.value, {
+    hitsPerPage: DOCUMENTS_HITS_PER_PAGE,
+    indexUid: currentIndex.value,
+    compatParams: buildCompatibleSearchParams(
+      savedSearchState.value,
+      meiliCompat.value,
+    ),
+  });
+
 const openDocumentInPlayground = (documentId) => {
   theSettings.setPlaygroundSeed({
     type: "document",
@@ -606,9 +648,19 @@ const openDocumentInPlayground = (documentId) => {
   detailPanelTab.value = "playground";
 };
 
-const openSearchInPlayground = (seed) => {
-  theSettings.setPlaygroundSeed(seed);
+const openSearchInPlayground = () => {
+  theSettings.setPlaygroundSeed({
+    type: "search",
+    indexUid: currentIndex.value,
+    body: buildCurrentSearchBody(),
+  });
   detailPanelTab.value = "playground";
+};
+
+const copyCurrentSearchJson = async () => {
+  await copyText(JSON.stringify(buildCurrentSearchBody(), null, 2), {
+    successMessage: "Search JSON copied",
+  });
 };
 
 const isTypingTarget = (el) => {


### PR DESCRIPTION
## Summary
- Fixed facet filters clearing when switching Documents ↔ Playground (and other index tabs): `keep-alive` on tab panels plus SearchStateWatcher guard against empty `refinementList` teardown snapshots that wiped filters while query stuck.
- Added Documents → Playground search bridge: pure helpers build a full Meilisearch body (`q`, `filter`, `sort`, `limit`/`offset`, hybrid/compat) from `indexSearchState`; toolbar and diagnostics offer **Open in Playground** and **Copy search JSON**.
- Bumped version to 2.3.1.

## Test plan
- [ ] On Documents, apply a facet filter and a query; switch to Playground then back; confirm filters and query both remain.
- [ ] Switch to Settings/Overview and back; filters still present.
- [ ] **Open in Playground** seeds `POST /indexes/:uid/search` with filter/sort/q and knobs sync.
- [ ] **Copy search JSON** copies the same body.
- [ ] Clear facets intentionally still clears and persists empty filters.